### PR TITLE
Add REST and A2A sample clients for WorkIQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,34 +45,6 @@ Register an app in [Azure portal](https://portal.azure.com) > Microsoft Entra ID
 
 After adding permissions, click **Grant admin consent for [your tenant]**.
 
-### 4. Service principal setup (new tenants)
-
-If you're using a newly created test tenant, the Work IQ service principals may not exist yet. You'll see an error like:
-
-```
-AADSTS650052: The app is trying to access a service '...' that your organization lacks a service principal for.
-```
-
-Fix this by creating the required service principals:
-
-```bash
-# Sign into your tenant
-az login --allow-no-subscriptions --tenant <your-tenant-id>
-
-# Create the service principals
-az ad sp create --id ba081686-5d24-4bc6-a0d6-d034ecffed87
-az ad sp create --id ea9ffc3e-8a23-4a7d-836d-234d7c7565c1
-
-# Grant admin consent
-az ad app permission admin-consent --id ba081686-5d24-4bc6-a0d6-d034ecffed87
-```
-
-Or use the admin consent URL (creates SPs and grants consent in one step):
-
-```
-https://login.microsoftonline.com/<your-tenant-id>/adminconsent?client_id=ba081686-5d24-4bc6-a0d6-d034ecffed87
-```
-
 ## Authentication
 
 Both samples support two authentication methods:
@@ -126,10 +98,8 @@ Tokens are held **in memory only** for the duration of the session. Each run req
 
 | Issue | Cause | Fix |
 |-------|-------|-----|
-| `AADSTS650052: lacks a service principal` | Service principal doesn't exist in your tenant | See [Service principal setup](#4-service-principal-setup-new-tenants) above |
-| `AADSTS65001: consent required` | Admin hasn't consented to the required permissions | Grant admin consent in Azure portal or via the admin consent URL |
+| `AADSTS65001: consent required` | Admin hasn't consented to the required permissions | Grant admin consent in Azure portal: Entra ID > App registrations > your app > API permissions > Grant admin consent |
 | `403 Forbidden` | Missing Copilot license or missing permissions | Verify the user has a Copilot license and all 7 permissions are consented |
-| `A window handle must be configured` | Running on Windows without WAM native interop | Build with `-r win-x64`: `dotnet run -r win-x64 -- ...` |
 | Empty or degraded responses | License just assigned, index not ready | Wait 15-30 minutes after license assignment for propagation |
 | `401 Unauthorized` | Token audience mismatch | Ensure token audience is `https://graph.microsoft.com` |
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,142 @@
+# Work IQ Samples
+
+Sample clients for the [Work IQ](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/workiq-overview) API — Microsoft's AI-native interface to Microsoft 365 work intelligence.
+
+| Sample | Protocol | Description |
+|--------|----------|-------------|
+| [**a2a/**](a2a/) | [A2A (Agent-to-Agent)](https://a2a-protocol.org) | Interactive agent session using the open A2A protocol over JSON-RPC |
+| [**rest/**](rest/) | REST | Interactive chat using the [Copilot Chat API](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview) with sync and streaming modes |
+
+Both samples are single-file, minimal-dependency .NET console apps designed to be read, modified, and used as starting points for your own integration.
+
+> **Current state**: Work IQ is accessed through the Microsoft Graph API at `graph.microsoft.com`. All samples use Graph endpoints and Graph authentication today.
+>
+> **What's coming**: A dedicated Work IQ gateway (`workiq.svc.cloud.microsoft`) with its own app registration, scopes (`WorkIQAgent.Ask`), and endpoint. When available, these samples will be updated with the new endpoint and auth model. Your integration code will change minimally — different token audience and endpoint URL, same protocols.
+
+## Prerequisites
+
+### 1. .NET SDK
+
+[.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later.
+
+### 2. Microsoft 365 Copilot license
+
+The Chat API is only available to users with a **Microsoft 365 Copilot** add-on license. Users without the license will get access denied errors. See [licensing docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview#licensing).
+
+### 3. Azure AD app registration
+
+Register an app in [Azure portal](https://portal.azure.com) > Microsoft Entra ID > App registrations:
+
+- **Supported account types**: Accounts in any organizational directory (multi-tenant)
+- **Redirect URI**: `http://localhost` (type: Web) for browser-based auth, or leave empty for WAM
+- **API permissions**: Add the following **delegated** Microsoft Graph permissions:
+
+| Permission | Description |
+|-----------|-------------|
+| `Sites.Read.All` | Read SharePoint sites |
+| `Mail.Read` | Read user mail |
+| `People.Read.All` | Read people data |
+| `OnlineMeetingTranscript.Read.All` | Read meeting transcripts |
+| `Chat.Read` | Read Teams chats |
+| `ChannelMessage.Read.All` | Read Teams channel messages |
+| `ExternalItem.Read.All` | Read external connector items |
+
+**All seven are required.** Missing any one will result in auth errors. See [permissions docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat#permissions).
+
+After adding permissions, click **Grant admin consent for [your tenant]**.
+
+### 4. Service principal setup (new tenants)
+
+If you're using a newly created test tenant, the Work IQ service principals may not exist yet. You'll see an error like:
+
+```
+AADSTS650052: The app is trying to access a service '...' that your organization lacks a service principal for.
+```
+
+Fix this by creating the required service principals:
+
+```bash
+# Sign into your tenant
+az login --allow-no-subscriptions --tenant <your-tenant-id>
+
+# Create the service principals
+az ad sp create --id ba081686-5d24-4bc6-a0d6-d034ecffed87
+az ad sp create --id ea9ffc3e-8a23-4a7d-836d-234d7c7565c1
+
+# Grant admin consent
+az ad app permission admin-consent --id ba081686-5d24-4bc6-a0d6-d034ecffed87
+```
+
+Or use the admin consent URL (creates SPs and grants consent in one step):
+
+```
+https://login.microsoftonline.com/<your-tenant-id>/adminconsent?client_id=ba081686-5d24-4bc6-a0d6-d034ecffed87
+```
+
+## Authentication
+
+Both samples support two authentication methods:
+
+### WAM (Windows Account Manager) — recommended on Windows
+
+Uses the Windows broker for silent SSO. No browser popup for returning users.
+
+```bash
+dotnet run -- --token WAM --appid <your-app-client-id>
+
+# With account hint (skips account picker)
+dotnet run -- --token WAM --appid <your-app-client-id> --account user@contoso.com
+```
+
+### Pre-obtained JWT token — any platform
+
+Acquire a token externally (e.g., via [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer), `az account get-access-token`, or your own MSAL code) and pass it directly:
+
+```bash
+dotnet run -- --token eyJ0eXAiOiJKV1Qi...
+```
+
+The token must have:
+- **Audience**: `https://graph.microsoft.com`
+- **Scopes**: all 7 delegated permissions listed above
+
+### Print token for reuse
+
+```bash
+dotnet run -- --token WAM --appid <your-app-client-id> --show-token
+# Copy the printed token, then reuse:
+dotnet run -- --token <paste-token-here>
+```
+
+## Platform support
+
+| Platform | Auth method | Status |
+|----------|------------|--------|
+| **Windows** | WAM broker (silent SSO) | Tested |
+| **macOS** | Interactive browser login | Should work (untested) |
+| **Linux / WSL** | Interactive browser login | Should work (untested) |
+
+On macOS/Linux, `--token WAM` is not available. Use `--token <JWT>` with a pre-obtained token, or MSAL will fall back to interactive browser authentication.
+
+## Token caching
+
+Tokens are held **in memory only** for the duration of the session. Each run requires fresh authentication. For production applications, consider using [MSAL token cache serialization](https://learn.microsoft.com/en-us/entra/msal/dotnet/how-to/token-cache-serialization) with platform-appropriate encryption (DPAPI on Windows, Keychain on macOS, keyring on Linux).
+
+## Common issues
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `AADSTS650052: lacks a service principal` | Service principal doesn't exist in your tenant | See [Service principal setup](#4-service-principal-setup-new-tenants) above |
+| `AADSTS65001: consent required` | Admin hasn't consented to the required permissions | Grant admin consent in Azure portal or via the admin consent URL |
+| `403 Forbidden` | Missing Copilot license or missing permissions | Verify the user has a Copilot license and all 7 permissions are consented |
+| `A window handle must be configured` | Running on Windows without WAM native interop | Build with `-r win-x64`: `dotnet run -r win-x64 -- ...` |
+| Empty or degraded responses | License just assigned, index not ready | Wait 15-30 minutes after license assignment for propagation |
+| `401 Unauthorized` | Token audience mismatch | Ensure token audience is `https://graph.microsoft.com` |
+
+## Resources
+
+- [Work IQ Overview](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/workiq-overview)
+- [Copilot Chat API](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview)
+- [A2A Protocol Specification](https://a2a-protocol.org/latest/specification/)
+- [Microsoft Graph Permissions Reference](https://learn.microsoft.com/en-us/graph/permissions-reference)
+- [MSAL.NET Documentation](https://learn.microsoft.com/en-us/entra/msal/dotnet/)

--- a/a2a/Program.cs
+++ b/a2a/Program.cs
@@ -1,0 +1,475 @@
+// WorkIQ A2A Sample — Interactive A2A session via Graph RP or WorkIQ Gateway
+// Usage: dotnet run -- --graph --token <JWT|WAM> --appid <clientId> [options]
+//        dotnet run -- --workiq --token <JWT|WAM> --appid <clientId> [options]
+
+using System.Diagnostics;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using A2A;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Broker;
+
+var config = ParseArgs(args);
+if (config == null) return;
+
+string token;
+IPublicClientApplication? msalApp = null;
+IAccount? msalAccount = null;
+
+if (config.Token.Equals("WAM", StringComparison.OrdinalIgnoreCase))
+{
+    var r = await AcquireWamToken(config.AppId, config.Gateway.Scopes, config.Account);
+    token = r.token; msalApp = r.app; msalAccount = r.account;
+}
+else
+{
+    token = config.Token;
+}
+
+if (config.Verbosity >= 1)
+{
+    Log("TOKEN");
+    DecodeToken(token);
+    if (config.ShowToken) Console.WriteLine($"\n  {token}\n");
+}
+
+WireLog.Verbosity = config.Verbosity;
+var httpClient = CreateHttpClient(token, config.Gateway);
+var a2a = new A2AClient(new Uri(config.Gateway.Endpoint), httpClient);
+string? contextId = null;
+
+if (config.Verbosity >= 1)
+{
+    Log($"READY — {config.Gateway.Name} — {(config.Stream ? "Streaming" : "Sync")} — {config.Gateway.Endpoint}");
+    Console.WriteLine("Type a message. 'quit' to exit.\n");
+}
+
+while (true)
+{
+    if (config.Verbosity >= 1) Ink("You > ", ConsoleColor.Cyan);
+    var input = Console.ReadLine();
+    if (string.IsNullOrWhiteSpace(input) || input.Equals("quit", StringComparison.OrdinalIgnoreCase)) break;
+
+    // Silent token refresh
+    if (msalApp != null)
+    {
+        try
+        {
+            var r = await AcquireWamToken(config.AppId, config.Gateway.Scopes, config.Account, msalApp, msalAccount);
+            token = r.token; msalAccount = r.account;
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+        catch { /* use cached */ }
+    }
+
+    if (config.Verbosity >= 1) Ink("Agent > ", ConsoleColor.Green);
+    try
+    {
+        var msg = new AgentMessage
+        {
+            Role = MessageRole.User,
+            MessageId = Guid.NewGuid().ToString(),
+            ContextId = contextId,
+            Parts = [new TextPart { Text = input }],
+            Metadata = new Dictionary<string, JsonElement>
+            {
+                ["Location"] = JsonSerializer.SerializeToElement(new { timeZoneOffset = (int)TimeZoneInfo.Local.BaseUtcOffset.TotalMinutes, timeZone = TimeZoneInfo.Local.Id }),
+            },
+        };
+
+        var sw = Stopwatch.StartNew();
+        Dictionary<string, JsonElement>? responseMetadata = null;
+
+        if (config.Stream)
+        {
+            var previousText = string.Empty;
+            await foreach (var sseItem in a2a.SendMessageStreamingAsync(new MessageSendParams { Message = msg }))
+            {
+                if (sseItem.Data is TaskStatusUpdateEvent statusUpdate)
+                {
+                    if (statusUpdate.Status.Message is AgentMessage agentMsg)
+                    {
+                        contextId = agentMsg.ContextId;
+                        responseMetadata = agentMsg.Metadata;
+
+                        // -v 1+: show A2A event details (state, part types, sizes)
+                        if (config.Verbosity >= 1)
+                        {
+                            var parts = agentMsg.Parts.Select(p => p switch
+                            {
+                                TextPart tp => $"TextPart({tp.Text?.Length ?? 0}c)",
+                                DataPart dp => $"DataPart",
+                                FilePart fp => $"FilePart({fp.File?.Name ?? "?"})",
+                                _ => p.GetType().Name
+                            });
+                            Ink($"  [{statusUpdate.Status.State}] {string.Join(" + ", parts)}\n", ConsoleColor.DarkGray);
+                        }
+
+                        var combined = string.Join("", agentMsg.Parts.OfType<TextPart>().Select(p => p.Text));
+
+                        // Print text delta
+                        if (combined.StartsWith(previousText, StringComparison.Ordinal))
+                        {
+                            Console.Write(combined[previousText.Length..]);
+                            previousText = combined;
+                        }
+                        else
+                        {
+                            Console.Write(combined);
+                            previousText = combined;
+                        }
+                    }
+
+                    if (statusUpdate.Final || statusUpdate.Status.State == TaskState.Completed)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            sw.Stop();
+            Console.WriteLine();
+        }
+        else
+        {
+            var response = await a2a.SendMessageAsync(new MessageSendParams { Message = msg });
+            sw.Stop();
+            var (text, ctx, meta) = Extract(response);
+            contextId = ctx;
+            responseMetadata = meta;
+            Console.WriteLine(text);
+        }
+
+        if (config.Verbosity >= 1) Ink($"  ({sw.ElapsedMilliseconds} ms)\n", ConsoleColor.DarkGray);
+
+        // Parse citations from metadata["attributions"]
+        if (responseMetadata != null) PrintCitations(responseMetadata, config.Verbosity);
+    }
+    catch (Exception ex)
+    {
+        Ink($"\n  ERROR: {ex.GetType().Name}: {ex.Message}\n", ConsoleColor.Red);
+        if (ex.InnerException != null) Ink($"  INNER: {ex.InnerException.Message}\n", ConsoleColor.Red);
+    }
+
+    Console.WriteLine();
+}
+
+// ── Core helpers ─────────────────────────────────────────────────────────
+
+static (string text, string? contextId, Dictionary<string, JsonElement>? metadata) Extract(object response) => response switch
+{
+    AgentMessage am => (Join(am), am.ContextId, am.Metadata),
+    AgentTask { Status: { State: TaskState.Completed, Message: AgentMessage cm } } t => (Join(cm), t.ContextId, cm.Metadata),
+    AgentTask t => ($"[Task {t.Id} — {t.Status.State}]", t.ContextId, null),
+    _ => ("(no response)", null, null),
+};
+
+static string Join(AgentMessage m) => string.Join("\n", m.Parts.OfType<TextPart>().Select(p => p.Text));
+
+static HttpClient CreateHttpClient(string bearerToken, GatewayConfig gw)
+{
+    var client = new HttpClient(new WireLog { InnerHandler = new HttpClientHandler() }) { Timeout = TimeSpan.FromMinutes(5) };
+    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+    foreach (var h in gw.ExtraHeaders)
+    {
+        var parts = h.Split(':', 2);
+        client.DefaultRequestHeaders.Add(parts[0].Trim(), parts[1].Trim());
+    }
+
+    return client;
+}
+
+// ── WAM auth ─────────────────────────────────────────────────────────────
+
+static async Task<(string token, IPublicClientApplication app, IAccount? account)> AcquireWamToken(
+    string clientId, string[] scopes, string? accountHint,
+    IPublicClientApplication? existingApp = null, IAccount? existingAccount = null)
+{
+    var app = existingApp;
+    if (app == null)
+    {
+        var builder = PublicClientApplicationBuilder.Create(clientId)
+            .WithDefaultRedirectUri()
+            .WithAuthority("https://login.microsoftonline.com/common");
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            builder.WithParentActivityOrWindow(ConsoleWindowHandle).WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
+        }
+
+        app = builder.Build();
+    }
+
+    AuthenticationResult result;
+    try
+    {
+        if (existingAccount != null)
+        {
+            result = await app.AcquireTokenSilent(scopes, existingAccount).ExecuteAsync();
+        }
+        else if (!string.IsNullOrEmpty(accountHint))
+        {
+            var cached = (await app.GetAccountsAsync()).FirstOrDefault(a => a.Username?.Contains(accountHint, StringComparison.OrdinalIgnoreCase) == true);
+            result = cached != null
+                ? await app.AcquireTokenSilent(scopes, cached).ExecuteAsync()
+                : await app.AcquireTokenInteractive(scopes).WithLoginHint(accountHint).ExecuteAsync();
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            result = await app.AcquireTokenSilent(scopes, PublicClientApplication.OperatingSystemAccount).ExecuteAsync();
+        }
+        else
+        {
+            result = await app.AcquireTokenInteractive(scopes).ExecuteAsync();
+        }
+    }
+    catch (MsalUiRequiredException)
+    {
+        result = await app.AcquireTokenInteractive(scopes).ExecuteAsync();
+    }
+
+    return (result.AccessToken, app, result.Account);
+}
+
+// ── Token decode ─────────────────────────────────────────────────────────
+
+static void DecodeToken(string token)
+{
+    try
+    {
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(token);
+        foreach (var c in new[] { "aud", "appid", "app_displayname", "tid", "upn", "name", "scp" })
+        {
+            var v = jwt.Claims.FirstOrDefault(x => x.Type == c)?.Value;
+            if (!string.IsNullOrEmpty(v)) Console.WriteLine($"  {c,-16} {v}");
+        }
+
+        var left = jwt.ValidTo - DateTime.UtcNow;
+        Ink($"  {"expires",-16} {jwt.ValidTo:HH:mm:ss} UTC ({(left.TotalMinutes > 0 ? $"{left.TotalMinutes:F0}m" : "EXPIRED")})\n",
+            left.TotalMinutes < 5 ? ConsoleColor.Red : ConsoleColor.Gray);
+    }
+    catch (Exception ex) { Ink($"  decode failed: {ex.Message}\n", ConsoleColor.Red); }
+}
+
+// ── Args ─────────────────────────────────────────────────────────────────
+
+static Config? ParseArgs(string[] args)
+{
+    string? token = null, appId = null, endpoint = null, account = null;
+    bool graph = false, workiq = false, showToken = false, stream = false;
+    int verbosity = 1;
+    var headers = new List<string>();
+
+    for (int i = 0; i < args.Length; i++)
+    {
+        switch (args[i])
+        {
+            case "--graph": graph = true; break;
+            case "--workiq": workiq = true; break;
+            case "--token" or "-t": token = args[++i]; break;
+            case "--appid" or "-a": appId = args[++i]; break;
+            case "--endpoint" or "-e": endpoint = args[++i]; break;
+            case "--account": account = args[++i]; break;
+            case "--show-token": showToken = true; break;
+            case "--stream": stream = true; break;
+            case "--verbosity" or "-v": verbosity = int.Parse(args[++i]); break;
+            case "--header" or "-H": headers.Add(args[++i]); break;
+        }
+    }
+
+    if (string.IsNullOrEmpty(token) || (!graph && !workiq))
+    {
+        Console.WriteLine("""
+            WorkIQ A2A Sample — Interactive A2A agent session
+
+            Usage: dotnet run -- <gateway> --token <JWT|WAM> --appid <clientId> [options]
+
+            Gateway (exactly one required):
+              --graph          Use Microsoft Graph RP gateway
+              --workiq         Use WorkIQ Gateway (coming soon)
+
+            Auth:
+              --token, -t      Bearer token or 'WAM' for Windows broker auth
+              --appid, -a      App client ID (required with WAM)
+              --account        Account hint (e.g. user@contoso.com)
+
+            Options:
+              --endpoint, -e   Override default gateway endpoint
+              --header, -H     Custom HTTP header in 'Key: Value' format (repeatable)
+              --show-token     Print the raw JWT token (for reuse with --token)
+              --stream         Use streaming mode (SSE via message/stream)
+              -v, --verbosity  0 = response only, 1 = default, 2 = full wire
+
+            Examples:
+              dotnet run -- --graph --token WAM --appid <your-app-id>
+              dotnet run -- --graph --token WAM --appid <your-app-id> --account user@contoso.com
+              dotnet run -- --graph --token eyJ0eXAi...
+            """);
+        return null;
+    }
+
+    if (graph && workiq)
+    {
+        Ink("ERROR: specify --graph or --workiq, not both\n", ConsoleColor.Red);
+        return null;
+    }
+
+    if (workiq)
+    {
+        Ink("ERROR: --workiq gateway is not yet implemented\n", ConsoleColor.Yellow);
+        return null;
+    }
+
+    if (token.Equals("WAM", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(appId))
+    {
+        Ink("ERROR: --appid is required when using --token WAM\n", ConsoleColor.Red);
+        return null;
+    }
+
+    var gw = graph ? Gateways.Graph : Gateways.WorkIQ;
+    if (!string.IsNullOrEmpty(endpoint))
+    {
+        gw = gw with { Endpoint = endpoint };
+    }
+
+    if (headers.Count > 0)
+    {
+        gw = gw with { ExtraHeaders = [.. gw.ExtraHeaders, .. headers] };
+    }
+
+    return new Config(token, appId ?? "", gw, account, showToken, verbosity, stream);
+}
+
+// ── Citations ─────────────────────────────────────────────────────────────
+
+static void PrintCitations(Dictionary<string, JsonElement>? metadata, int verbosity)
+{
+    if (metadata == null || !metadata.TryGetValue("attributions", out var attrs) || attrs.ValueKind != JsonValueKind.Array)
+        return;
+
+    var citations = new List<(string type, string source, string provider, string url)>();
+    foreach (var attr in attrs.EnumerateArray())
+    {
+        var type = attr.TryGetProperty("attributionType", out var t) ? t.ToString() : "";
+        var source = attr.TryGetProperty("attributionSource", out var s) ? s.ToString() : "";
+        var provider = attr.TryGetProperty("providerDisplayName", out var p) ? p.GetString() ?? "" : "";
+        var url = attr.TryGetProperty("seeMoreWebUrl", out var u) ? u.GetString() ?? "" : "";
+        citations.Add((type, source, provider, url));
+    }
+
+    if (citations.Count == 0) return;
+
+    var citationCount = citations.Count(c => c.type.Contains("citation", StringComparison.OrdinalIgnoreCase));
+    var annotationCount = citations.Count(c => c.type.Contains("annotation", StringComparison.OrdinalIgnoreCase));
+
+    if (verbosity >= 1)
+    {
+        Ink($"  Citations: {citationCount}  Annotations: {annotationCount}\n", ConsoleColor.DarkYellow);
+    }
+
+    if (verbosity >= 2)
+    {
+        foreach (var (type, source, provider, url) in citations)
+        {
+            var label = type.Contains("citation", StringComparison.OrdinalIgnoreCase) ? "📄" : "🔗";
+            var name = !string.IsNullOrEmpty(provider) ? provider : "(unnamed)";
+            Console.ForegroundColor = type.Contains("citation", StringComparison.OrdinalIgnoreCase) ? ConsoleColor.Yellow : ConsoleColor.DarkGray;
+            Console.WriteLine($"    {label} [{type}/{source}] {name}");
+            if (!string.IsNullOrEmpty(url))
+            {
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                var truncUrl = url.Length <= 120 ? url : $"{url[..120]}...";
+                Console.WriteLine($"       {truncUrl}");
+            }
+        }
+
+        Console.ResetColor();
+    }
+}
+
+// ── Utilities ────────────────────────────────────────────────────────────
+
+static void Log(string s) { Ink($"\n── {s} ──\n", ConsoleColor.DarkGray); }
+static void Ink(string s, ConsoleColor c) { Console.ForegroundColor = c; Console.Write(s); Console.ResetColor(); }
+
+[DllImport("kernel32.dll", EntryPoint = "GetConsoleWindow")] static extern IntPtr Win32GetConsoleWindow();
+[DllImport("user32.dll", ExactSpelling = true)] static extern IntPtr GetAncestor(IntPtr hwnd, uint flags);
+static IntPtr ConsoleWindowHandle() { var c = Win32GetConsoleWindow(); var r = GetAncestor(c, 3); return r != IntPtr.Zero ? r : c; }
+
+record Config(string Token, string AppId, GatewayConfig Gateway, string? Account, bool ShowToken, int Verbosity, bool Stream);
+
+// ── Gateway definitions ──────────────────────────────────────────────────
+
+record GatewayConfig(string Name, string Endpoint, string[] Scopes, string Authority, string[] ExtraHeaders);
+
+class Gateways
+{
+    public static readonly GatewayConfig Graph = new(
+        Name: "Graph RP",
+        Endpoint: "https://graph.microsoft.com/rp/workiq/",
+        Scopes: ["https://graph.microsoft.com/.default"],
+        Authority: "https://login.microsoftonline.com/common",
+        ExtraHeaders: []);
+
+    public static readonly GatewayConfig WorkIQ = new(
+        Name: "WorkIQ Gateway",
+        Endpoint: "", // TODO: set when available
+        Scopes: [], // TODO: set when available
+        Authority: "https://login.microsoftonline.com/common",
+        ExtraHeaders: []);
+}
+
+// ── Wire logger ──────────────────────────────────────────────────────────
+
+class WireLog : DelegatingHandler
+{
+    public static int Verbosity { get; set; } = 1;
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
+    {
+        if (Verbosity >= 2)
+        {
+            Console.ForegroundColor = ConsoleColor.DarkGray;
+            Console.WriteLine($"\n  ▶ {req.Method} {req.RequestUri}");
+            foreach (var h in req.Headers)
+                Console.WriteLine(h.Key.Equals("Authorization", StringComparison.OrdinalIgnoreCase)
+                    ? $"    {h.Key}: Bearer ...({h.Value.First().Length}c)"
+                    : $"    {h.Key}: {string.Join(", ", h.Value)}");
+
+            if (req.Content is { } body)
+            {
+                foreach (var h in body.Headers) Console.WriteLine($"    {h.Key}: {string.Join(", ", h.Value)}");
+                var text = await body.ReadAsStringAsync(ct);
+                Console.WriteLine($"    Body: {Trunc(text, 500)}");
+            }
+
+            Console.ResetColor();
+        }
+
+        HttpResponseMessage res;
+        try { res = await base.SendAsync(req, ct); }
+        catch (Exception ex) { Ink($"  ◀ ERROR: {ex.Message}\n", ConsoleColor.Red); throw; }
+
+        if (Verbosity >= 2)
+        {
+            Console.ForegroundColor = (int)res.StatusCode >= 400 ? ConsoleColor.Red : ConsoleColor.DarkGray;
+            Console.WriteLine($"  ◀ {(int)res.StatusCode} {res.StatusCode}");
+            foreach (var h in res.Headers) Console.WriteLine($"    {h.Key}: {string.Join(", ", h.Value)}");
+            if (res.Content != null)
+                foreach (var h in res.Content.Headers) Console.WriteLine($"    {h.Key}: {string.Join(", ", h.Value)}");
+
+            if ((int)res.StatusCode >= 400 && res.Content != null)
+                Console.WriteLine($"    Body: {Trunc(await res.Content.ReadAsStringAsync(ct), 1000)}");
+
+            Console.ResetColor();
+        }
+
+        return res;
+    }
+
+    static string Trunc(string s, int max) => s.Length <= max ? s : $"{s[..max]}...";
+    static void Ink(string s, ConsoleColor c) { Console.ForegroundColor = c; Console.Write(s); Console.ResetColor(); }
+}

--- a/a2a/Program.cs
+++ b/a2a/Program.cs
@@ -66,6 +66,8 @@ while (true)
     }
 
     if (config.Verbosity >= 1) Ink("Agent > ", ConsoleColor.Green);
+    var spinner = new Spinner();
+    spinner.Start();
     try
     {
         var msg = new AgentMessage
@@ -109,6 +111,7 @@ while (true)
                         }
 
                         var combined = string.Join("", agentMsg.Parts.OfType<TextPart>().Select(p => p.Text));
+                        spinner.Stop();
 
                         // Print text delta
                         if (combined.StartsWith(previousText, StringComparison.Ordinal))
@@ -137,6 +140,7 @@ while (true)
         {
             var response = await a2a.SendMessageAsync(new MessageSendParams { Message = msg });
             sw.Stop();
+            spinner.Stop();
             var (text, ctx, meta) = Extract(response);
             contextId = ctx;
             responseMetadata = meta;
@@ -150,6 +154,7 @@ while (true)
     }
     catch (Exception ex)
     {
+        spinner.Stop();
         Ink($"\n  ERROR: {ex.GetType().Name}: {ex.Message}\n", ConsoleColor.Red);
         if (ex.InnerException != null) Ink($"  INNER: {ex.InnerException.Message}\n", ConsoleColor.Red);
     }
@@ -472,4 +477,43 @@ class WireLog : DelegatingHandler
 
     static string Trunc(string s, int max) => s.Length <= max ? s : $"{s[..max]}...";
     static void Ink(string s, ConsoleColor c) { Console.ForegroundColor = c; Console.Write(s); Console.ResetColor(); }
+}
+
+// ── Spinner ─────────────────────────────────────────────────────────────
+
+class Spinner
+{
+    private static readonly string[] Frames = ["·  ", "·· ", "···", " ··", "  ·", "   "];
+    private CancellationTokenSource? cts;
+    private Task? task;
+
+    public void Start()
+    {
+        cts = new CancellationTokenSource();
+        var token = cts.Token;
+        task = Task.Run(async () =>
+        {
+            var i = 0;
+            Console.CursorVisible = false;
+            while (!token.IsCancellationRequested)
+            {
+                var frame = Frames[i % Frames.Length];
+                Console.Write(frame);
+                Console.SetCursorPosition(Console.CursorLeft - frame.Length, Console.CursorTop);
+                try { await Task.Delay(150, token); } catch { break; }
+                i++;
+            }
+            Console.Write("   ");
+            Console.SetCursorPosition(Console.CursorLeft - 3, Console.CursorTop);
+            Console.CursorVisible = true;
+        });
+    }
+
+    public void Stop()
+    {
+        if (cts == null) return;
+        cts.Cancel();
+        try { task?.Wait(); } catch { }
+        cts = null;
+    }
 }

--- a/a2a/README.md
+++ b/a2a/README.md
@@ -1,0 +1,261 @@
+# WorkIQ A2A Sample
+
+A minimal, single-file interactive client for communicating with WorkIQ agents using the [Agent2Agent (A2A) protocol](https://a2a-protocol.org).
+
+> **Preview (via Microsoft Graph):** During preview, WorkIQ is accessed through the Microsoft Graph API at `graph.microsoft.com`. When WorkIQ's dedicated infrastructure is available, the endpoint will move to `workiq.svc.cloud.dev.microsoft` with its own app registration (audience: `fdcc1f02-fc51-4226-8753-f668596af7f7`) and scopes. The code and instructions in this sample will be updated at that time.
+
+## What is A2A?
+
+The **Agent2Agent (A2A) Protocol** is an open standard (originally by Google, now under the Linux Foundation) for communication between AI agents. It defines JSON-RPC methods for sending messages, managing tasks, and streaming responses via Server-Sent Events.
+
+- 📖 [A2A Protocol Specification](https://a2a-protocol.org/latest/specification/)
+- 🧑‍💻 [A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) — the NuGet package used by this sample
+- 📦 [NuGet: A2A](https://www.nuget.org/packages/A2A/)
+
+## NuGet Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| [`A2A`](https://www.nuget.org/packages/A2A/) | 0.3.3-preview | A2A protocol client (JSON-RPC, message/send, message/stream) |
+| `Microsoft.Identity.Client` | 4.83.1 | MSAL token acquisition |
+| `Microsoft.Identity.Client.Broker` | 4.83.1 | Windows WAM (Web Account Manager) broker |
+| `System.IdentityModel.Tokens.Jwt` | 8.16.0 | JWT token decoding for diagnostics |
+
+> **Note:** This sample uses A2A SDK v0.3.3-preview. The A2A spec has since moved to v1.0. A [migration guide](https://github.com/a2aproject/a2a-dotnet/blob/main/docs/migration-guide-v1.md) and backward-compatible `A2A.V0_3` package are available if you need to upgrade.
+
+## Gateway Support
+
+| Gateway | Flag | Status | Endpoint |
+|---------|------|--------|----------|
+| Microsoft Graph RP | `--graph` | ✅ Working | `https://graph.microsoft.com/rp/workiq/` |
+| WorkIQ Gateway | `--workiq` | 🚧 Coming soon | TBD |
+
+## Usage
+
+```bash
+# Build
+dotnet build
+
+# Run with WAM (Windows broker auth — recommended)
+dotnet run -- --graph --token WAM --appid <your-app-client-id>
+
+# Run with WAM + account hint (skips account picker)
+dotnet run -- --graph --token WAM --appid <your-app-client-id> --account user@contoso.com
+
+# Run with a pre-obtained JWT token
+dotnet run -- --graph --token eyJ0eXAiOiJKV1Qi...
+
+# Get a token via WAM, print it, then reuse it
+dotnet run -- --graph --token WAM --appid <your-app-client-id> --show-token
+# Copy the printed token, then:
+dotnet run -- --graph --token <paste-token-here>
+```
+
+### Parameters
+
+| Flag | Description |
+|------|-------------|
+| `--graph` | Use Microsoft Graph RP gateway (required, or `--workiq`) |
+| `--workiq` | Use WorkIQ Gateway — not yet implemented |
+| `--token`, `-t` | Bearer JWT token, or `WAM` for Windows broker auth |
+| `--appid`, `-a` | Azure AD app client ID (required with `--token WAM`) |
+| `--account` | Account hint for WAM (e.g. `user@contoso.com`) |
+| `--endpoint`, `-e` | Override the default gateway endpoint URL |
+| `--show-token` | Print the raw JWT after decoding (for reuse) |
+
+## How It Works
+
+```
+┌──────────────┐     JSON-RPC POST       ┌──────────────────┐
+│  This Sample │ ──────────────────────►  │  Microsoft Graph │
+│  (A2A Client)│ ◄──────────────────────  │  Copilot API     │
+└──────────────┘   AgentMessage response  └──────────────────┘
+```
+
+1. **Auth**: Acquires a token with `audience: https://graph.microsoft.com` via WAM or accepts a pre-obtained JWT
+2. **A2A Client**: Creates an `A2AClient` from the [A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) pointed at the Graph RP endpoint
+3. **Send**: Sends `message/send` (sync) or `message/stream` (streaming) JSON-RPC requests with user input as `TextPart`
+4. **Receive**: Parses `AgentMessage` or `AgentTask` responses, extracts text parts and citations from metadata
+5. **Multi-turn**: Maintains `contextId` across turns for conversation continuity
+
+## A2A Protocol Compliance
+
+### What works today
+
+| A2A Capability | Status | Notes |
+|---------------|--------|-------|
+| `message/send` (sync) | ✅ Works | Full request/response cycle |
+| `message/stream` (SSE) | ✅ Works | Incremental streaming via `TaskStatusUpdateEvent` |
+| Multi-turn (`contextId`) | ✅ Works | Conversation state maintained across turns |
+| `TextPart` messages | ✅ Works | User and agent text messages |
+| Citations | ✅ Works | Via Microsoft-specific `metadata["attributions"]` (see [Citations](#citations-microsoft-specific-extension)) |
+
+### Known limitations
+
+The following A2A capabilities are **not yet available** and are being actively developed.
+
+#### Agent card retrieval
+
+Per the [A2A spec](https://a2a-protocol.org/latest/specification/), an A2A client typically fetches an agent card from `/.well-known/agent.json` to discover capabilities and the endpoint URL. This is **not yet supported**. The sample connects directly to the Microsoft 365 Copilot agent endpoint.
+
+**Coming soon**: Agent card support with correct endpoint discovery.
+
+#### Agent discovery
+
+Agent discovery — finding which agents are available — is **not part of the A2A protocol**. The A2A spec defines communication with a known agent, not how to discover agents. A Microsoft-specific agent listing mechanism is planned but **not yet available**.
+
+**Current approach**: This sample connects directly to the default **Microsoft 365 Copilot** agent. Support for discovering and selecting other agents is coming soon.
+
+#### Platform support
+
+| Platform | Auth method | Status |
+|----------|------------|--------|
+| **Windows** | WAM broker (silent SSO) | ✅ Tested |
+| **macOS** | Interactive browser login | 🔄 Untested (should work) |
+| **Linux / WSL** | Interactive browser login | 🔄 Untested (should work) |
+
+On Windows, `--token WAM` uses the Windows Account Manager for silent SSO (no browser popup). On macOS/Linux, MSAL falls back to interactive browser authentication. You can also use `--token <JWT>` on any platform with a pre-obtained token.
+
+#### Token caching
+Tokens are held **in memory only** for the duration of the session — they are not persisted to disk. Each run requires a fresh authentication. For production applications, consider using [MSAL token cache serialization](https://learn.microsoft.com/en-us/entra/msal/dotnet/how-to/token-cache-serialization) with platform-appropriate encryption (DPAPI on Windows, Keychain on macOS, keyring on Linux).
+
+#### Summary
+
+| A2A Feature | Status | Current Approach |
+|------------|--------|-----------------|
+| `message/send` (sync) | ✅ Available | Standard A2A JSON-RPC |
+| `message/stream` (SSE) | ✅ Available | Standard A2A streaming |
+| Multi-turn (`contextId`) | ✅ Available | Maintained across turns |
+| Agent card (`/.well-known/agent.json`) | 🚧 Coming soon | Use endpoint URL directly |
+| Agent discovery / listing | 🚧 Coming soon | Connect to M365 Copilot agent directly |
+| macOS / Linux / WSL auth | 🔄 Untested | Interactive browser login (WAM is Windows-only) |
+
+> **For now**, use the Microsoft 365 Copilot agent endpoint (`https://graph.microsoft.com/rp/workiq/`) directly. Agent card retrieval, agent discovery, and cross-platform auth will be enabled in upcoming releases.
+
+## Gotchas
+
+### Graph RP streaming support
+Both `message/send` (sync) and `message/stream` (SSE streaming) work via Graph RP. Use `--stream` for incremental response output.
+
+### App ID is required with WAM
+When using `--token WAM`, you must provide `--appid` with your Azure AD app registration's client ID. The app must have appropriate Microsoft Graph delegated permissions.
+
+### Required permissions (all seven are mandatory)
+The Chat API requires **all** of these delegated permissions to be consented on your app registration:
+`Sites.Read.All`, `Mail.Read`, `People.Read.All`, `OnlineMeetingTranscript.Read.All`, `Chat.Read`, `ChannelMessage.Read.All`, `ExternalItem.Read.All`. Missing any one will result in auth errors. See [permissions docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat#permissions).
+
+### Microsoft 365 Copilot license required
+The Chat API is only available to users with a Microsoft 365 Copilot add-on license. Users without the license will get access denied errors.
+
+### Token audience must be `https://graph.microsoft.com`
+The Graph RP rejects tokens with other audiences. If using a pre-obtained token, ensure it was acquired with `scope: https://graph.microsoft.com/.default`.
+
+### A2A SDK version
+This sample uses `A2A` v0.3.3-preview which implements the [A2A v0.3 spec](https://a2a-protocol.org). The protocol has since moved to v1.0 with breaking changes (renamed types, new methods). See the [migration guide](https://github.com/a2aproject/a2a-dotnet/blob/main/docs/migration-guide-v1.md) when upgrading.
+
+## Citations (Microsoft-specific extension)
+
+> **Important:** Citations are delivered via a **Microsoft-specific extension** to the A2A protocol — not part of the [A2A spec](https://a2a-protocol.org). This format is specific to Microsoft 365 Copilot and is subject to change. When WorkIQ moves to its dedicated gateway, citations may be delivered using A2A-native `DataPart` or a formal A2A extension mechanism.
+
+### How citations work in A2A
+
+The standard A2A protocol defines `TextPart`, `FilePart`, and `DataPart` as message parts, but has no built-in citation type. Microsoft 365 Copilot delivers citations via the `AgentMessage.Metadata` dictionary under the key `"attributions"`.
+
+### Citation schema
+
+```json
+// AgentMessage.Metadata["attributions"]
+[
+  {
+    "attributionType": "Citation",          // "Citation" or "Annotation"
+    "attributionSource": "Model",           // "Model" (cited in response) or "Grounding" (used but not cited)
+    "providerDisplayName": "Q3 Planning",   // Display name of the source
+    "seeMoreWebUrl": "https://...",         // Link to the source
+    "imageWebUrl": "",                      // Optional image URL
+    "imageFavIcon": "",                     // Optional favicon
+    "imageWidth": 0,                        // Optional image dimensions
+    "imageHeight": 0
+  }
+]
+```
+
+### Attribution types
+
+| Type | Meaning | Example |
+|------|---------|---------|
+| `Citation` | Source explicitly referenced in the response text (e.g., `[1]`) | A meeting, email, or document |
+| `Annotation` | Entity recognized in the response but not numbered | A person mention, team name |
+
+### Attribution sources
+
+| Source | Meaning |
+|--------|---------|
+| `Model` | Used by the model to generate the response (cited) |
+| `Grounding` | Used for context/grounding but not directly cited |
+
+### Parsing in code
+
+```csharp
+// After receiving an AgentMessage (sync or streaming)
+if (agentMessage.Metadata?.TryGetValue("attributions", out var attrs) == true
+    && attrs.ValueKind == JsonValueKind.Array)
+{
+    foreach (var attr in attrs.EnumerateArray())
+    {
+        var type = attr.GetProperty("attributionType").ToString();     // "Citation" or "Annotation"
+        var source = attr.GetProperty("attributionSource").ToString(); // "Model" or "Grounding"
+        var name = attr.GetProperty("providerDisplayName").GetString();
+        var url = attr.GetProperty("seeMoreWebUrl").GetString();
+        
+        Console.WriteLine($"[{type}] {name} → {url}");
+    }
+}
+```
+
+### Sample output (`-v 2`)
+
+```
+Agent > You have 3 meetings scheduled tomorrow...
+  (22500 ms)
+  Citations: 3  Annotations: 2
+    📄 [Citation/Model] Q3 Planning Meeting
+       https://teams.microsoft.com/l/meeting/details?eventId=...
+    📄 [Citation/Model] Weekly Team Standup
+       https://teams.microsoft.com/l/meeting/details?eventId=...
+    🔗 [Annotation/Model] Jane Smith
+       https://www.office.com/search?q=Jane+Smith...
+```
+
+### Future direction
+
+When WorkIQ transitions to its dedicated gateway, citations will likely move to one of:
+1. **A2A `DataPart`** — structured data parts in the message (A2A-native)
+2. **A2A extension** — formal extension mechanism per A2A spec
+3. **Same metadata format** — carried forward for backward compatibility
+
+Monitor the [WorkIQ API documentation](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility) for updates.
+
+## Wire Diagnostics
+
+The sample includes a `WireLog` HTTP handler that prints full request/response diagnostics:
+
+```
+  ▶ POST https://graph.microsoft.com/rp/workiq/
+    Authorization: Bearer ...(3089c)
+    Content-Type: application/json
+    Body: {"jsonrpc":"2.0","method":"message/send","params":{...}}
+
+  ◀ 200 OK
+    request-id: d7d0989c-...
+    Content-Type: application/json
+```
+
+For errors (4xx/5xx), the full response body is printed in red.
+
+## Resources
+
+- [A2A Protocol Specification](https://a2a-protocol.org/latest/specification/)
+- [A2A .NET SDK (GitHub)](https://github.com/a2aproject/a2a-dotnet)
+- [A2A NuGet Package](https://www.nuget.org/packages/A2A/)
+- [Microsoft Graph Copilot Chat API](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat)
+- [WorkIQ CLI](https://github.com/nicholasgasior/work-iq-cli) _(reference implementation)_

--- a/a2a/README.md
+++ b/a2a/README.md
@@ -1,261 +1,137 @@
-# WorkIQ A2A Sample
+# Work IQ A2A Sample
 
-A minimal, single-file interactive client for communicating with WorkIQ agents using the [Agent2Agent (A2A) protocol](https://a2a-protocol.org).
+A minimal, single-file interactive client for communicating with Work IQ agents using the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org).
 
-> **Preview (via Microsoft Graph):** During preview, WorkIQ is accessed through the Microsoft Graph API at `graph.microsoft.com`. When WorkIQ's dedicated infrastructure is available, the endpoint will move to `workiq.svc.cloud.dev.microsoft` with its own app registration (audience: `fdcc1f02-fc51-4226-8753-f668596af7f7`) and scopes. The code and instructions in this sample will be updated at that time.
+> **Prerequisites, authentication, and common issues** are covered in the [root README](../README.md). Read that first.
 
 ## What is A2A?
 
-The **Agent2Agent (A2A) Protocol** is an open standard (originally by Google, now under the Linux Foundation) for communication between AI agents. It defines JSON-RPC methods for sending messages, managing tasks, and streaming responses via Server-Sent Events.
+The **Agent-to-Agent (A2A) Protocol** is an open standard for communication between AI agents. It defines JSON-RPC methods for sending messages, managing tasks, and streaming responses via Server-Sent Events.
 
-- 📖 [A2A Protocol Specification](https://a2a-protocol.org/latest/specification/)
-- 🧑‍💻 [A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) — the NuGet package used by this sample
-- 📦 [NuGet: A2A](https://www.nuget.org/packages/A2A/)
+- [A2A Protocol Specification](https://a2a-protocol.org/latest/specification/)
+- [A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) (NuGet: [`A2A`](https://www.nuget.org/packages/A2A/))
 
-## NuGet Dependencies
-
-| Package | Version | Purpose |
-|---------|---------|---------|
-| [`A2A`](https://www.nuget.org/packages/A2A/) | 0.3.3-preview | A2A protocol client (JSON-RPC, message/send, message/stream) |
-| `Microsoft.Identity.Client` | 4.83.1 | MSAL token acquisition |
-| `Microsoft.Identity.Client.Broker` | 4.83.1 | Windows WAM (Web Account Manager) broker |
-| `System.IdentityModel.Tokens.Jwt` | 8.16.0 | JWT token decoding for diagnostics |
-
-> **Note:** This sample uses A2A SDK v0.3.3-preview. The A2A spec has since moved to v1.0. A [migration guide](https://github.com/a2aproject/a2a-dotnet/blob/main/docs/migration-guide-v1.md) and backward-compatible `A2A.V0_3` package are available if you need to upgrade.
-
-## Gateway Support
-
-| Gateway | Flag | Status | Endpoint |
-|---------|------|--------|----------|
-| Microsoft Graph RP | `--graph` | ✅ Working | `https://graph.microsoft.com/rp/workiq/` |
-| WorkIQ Gateway | `--workiq` | 🚧 Coming soon | TBD |
-
-## Usage
+## Quick start
 
 ```bash
 # Build
 dotnet build
 
-# Run with WAM (Windows broker auth — recommended)
+# Run (sync mode)
 dotnet run -- --graph --token WAM --appid <your-app-client-id>
 
-# Run with WAM + account hint (skips account picker)
+# Run (streaming mode — SSE via message/stream)
+dotnet run -- --graph --token WAM --appid <your-app-client-id> --stream
+
+# With account hint
 dotnet run -- --graph --token WAM --appid <your-app-client-id> --account user@contoso.com
-
-# Run with a pre-obtained JWT token
-dotnet run -- --graph --token eyJ0eXAiOiJKV1Qi...
-
-# Get a token via WAM, print it, then reuse it
-dotnet run -- --graph --token WAM --appid <your-app-client-id> --show-token
-# Copy the printed token, then:
-dotnet run -- --graph --token <paste-token-here>
 ```
 
-### Parameters
+## Parameters
 
 | Flag | Description |
 |------|-------------|
-| `--graph` | Use Microsoft Graph RP gateway (required, or `--workiq`) |
-| `--workiq` | Use WorkIQ Gateway — not yet implemented |
+| `--graph` | Use Microsoft Graph RP gateway (required) |
 | `--token`, `-t` | Bearer JWT token, or `WAM` for Windows broker auth |
 | `--appid`, `-a` | Azure AD app client ID (required with `--token WAM`) |
 | `--account` | Account hint for WAM (e.g. `user@contoso.com`) |
 | `--endpoint`, `-e` | Override the default gateway endpoint URL |
+| `--header`, `-H` | Custom HTTP header in `Key: Value` format (repeatable) |
 | `--show-token` | Print the raw JWT after decoding (for reuse) |
+| `--stream` | Use streaming mode (SSE via `message/stream`) |
+| `-v`, `--verbosity` | `0` = response only, `1` = default, `2` = full wire diagnostics |
 
-## How It Works
+## How it works
 
 ```
 ┌──────────────┐     JSON-RPC POST       ┌──────────────────┐
-│  This Sample │ ──────────────────────►  │  Microsoft Graph │
-│  (A2A Client)│ ◄──────────────────────  │  Copilot API     │
+│  This Sample │ ──────────────────────>  │  Microsoft Graph │
+│  (A2A Client)│ <──────────────────────  │  Copilot API     │
 └──────────────┘   AgentMessage response  └──────────────────┘
 ```
 
-1. **Auth**: Acquires a token with `audience: https://graph.microsoft.com` via WAM or accepts a pre-obtained JWT
+1. **Auth**: Acquires a token via WAM or accepts a pre-obtained JWT
 2. **A2A Client**: Creates an `A2AClient` from the [A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) pointed at the Graph RP endpoint
-3. **Send**: Sends `message/send` (sync) or `message/stream` (streaming) JSON-RPC requests with user input as `TextPart`
-4. **Receive**: Parses `AgentMessage` or `AgentTask` responses, extracts text parts and citations from metadata
+3. **Send**: Sends `message/send` (sync) or `message/stream` (streaming) JSON-RPC requests
+4. **Receive**: Parses `AgentMessage` or `AgentTask` responses, extracts text and citations
 5. **Multi-turn**: Maintains `contextId` across turns for conversation continuity
 
-## A2A Protocol Compliance
-
-### What works today
+## A2A protocol compliance
 
 | A2A Capability | Status | Notes |
 |---------------|--------|-------|
-| `message/send` (sync) | ✅ Works | Full request/response cycle |
-| `message/stream` (SSE) | ✅ Works | Incremental streaming via `TaskStatusUpdateEvent` |
-| Multi-turn (`contextId`) | ✅ Works | Conversation state maintained across turns |
-| `TextPart` messages | ✅ Works | User and agent text messages |
-| Citations | ✅ Works | Via Microsoft-specific `metadata["attributions"]` (see [Citations](#citations-microsoft-specific-extension)) |
+| `message/send` (sync) | Available | Full request/response cycle |
+| `message/stream` (SSE) | Available | Incremental streaming via `TaskStatusUpdateEvent` |
+| Multi-turn (`contextId`) | Available | Conversation state maintained across turns |
+| `TextPart` messages | Available | User and agent text messages |
+| Citations | Available | Via Microsoft-specific `metadata["attributions"]` (see below) |
+| Agent card (`/.well-known/agent.json`) | Coming soon | Connect to endpoint directly for now |
+| Agent discovery / listing | Coming soon | Connects to M365 Copilot agent directly for now |
 
-### Known limitations
+## Citations
 
-The following A2A capabilities are **not yet available** and are being actively developed.
-
-#### Agent card retrieval
-
-Per the [A2A spec](https://a2a-protocol.org/latest/specification/), an A2A client typically fetches an agent card from `/.well-known/agent.json` to discover capabilities and the endpoint URL. This is **not yet supported**. The sample connects directly to the Microsoft 365 Copilot agent endpoint.
-
-**Coming soon**: Agent card support with correct endpoint discovery.
-
-#### Agent discovery
-
-Agent discovery — finding which agents are available — is **not part of the A2A protocol**. The A2A spec defines communication with a known agent, not how to discover agents. A Microsoft-specific agent listing mechanism is planned but **not yet available**.
-
-**Current approach**: This sample connects directly to the default **Microsoft 365 Copilot** agent. Support for discovering and selecting other agents is coming soon.
-
-#### Platform support
-
-| Platform | Auth method | Status |
-|----------|------------|--------|
-| **Windows** | WAM broker (silent SSO) | ✅ Tested |
-| **macOS** | Interactive browser login | 🔄 Untested (should work) |
-| **Linux / WSL** | Interactive browser login | 🔄 Untested (should work) |
-
-On Windows, `--token WAM` uses the Windows Account Manager for silent SSO (no browser popup). On macOS/Linux, MSAL falls back to interactive browser authentication. You can also use `--token <JWT>` on any platform with a pre-obtained token.
-
-#### Token caching
-Tokens are held **in memory only** for the duration of the session — they are not persisted to disk. Each run requires a fresh authentication. For production applications, consider using [MSAL token cache serialization](https://learn.microsoft.com/en-us/entra/msal/dotnet/how-to/token-cache-serialization) with platform-appropriate encryption (DPAPI on Windows, Keychain on macOS, keyring on Linux).
-
-#### Summary
-
-| A2A Feature | Status | Current Approach |
-|------------|--------|-----------------|
-| `message/send` (sync) | ✅ Available | Standard A2A JSON-RPC |
-| `message/stream` (SSE) | ✅ Available | Standard A2A streaming |
-| Multi-turn (`contextId`) | ✅ Available | Maintained across turns |
-| Agent card (`/.well-known/agent.json`) | 🚧 Coming soon | Use endpoint URL directly |
-| Agent discovery / listing | 🚧 Coming soon | Connect to M365 Copilot agent directly |
-| macOS / Linux / WSL auth | 🔄 Untested | Interactive browser login (WAM is Windows-only) |
-
-> **For now**, use the Microsoft 365 Copilot agent endpoint (`https://graph.microsoft.com/rp/workiq/`) directly. Agent card retrieval, agent discovery, and cross-platform auth will be enabled in upcoming releases.
-
-## Gotchas
-
-### Graph RP streaming support
-Both `message/send` (sync) and `message/stream` (SSE streaming) work via Graph RP. Use `--stream` for incremental response output.
-
-### App ID is required with WAM
-When using `--token WAM`, you must provide `--appid` with your Azure AD app registration's client ID. The app must have appropriate Microsoft Graph delegated permissions.
-
-### Required permissions (all seven are mandatory)
-The Chat API requires **all** of these delegated permissions to be consented on your app registration:
-`Sites.Read.All`, `Mail.Read`, `People.Read.All`, `OnlineMeetingTranscript.Read.All`, `Chat.Read`, `ChannelMessage.Read.All`, `ExternalItem.Read.All`. Missing any one will result in auth errors. See [permissions docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat#permissions).
-
-### Microsoft 365 Copilot license required
-The Chat API is only available to users with a Microsoft 365 Copilot add-on license. Users without the license will get access denied errors.
-
-### Token audience must be `https://graph.microsoft.com`
-The Graph RP rejects tokens with other audiences. If using a pre-obtained token, ensure it was acquired with `scope: https://graph.microsoft.com/.default`.
-
-### A2A SDK version
-This sample uses `A2A` v0.3.3-preview which implements the [A2A v0.3 spec](https://a2a-protocol.org). The protocol has since moved to v1.0 with breaking changes (renamed types, new methods). See the [migration guide](https://github.com/a2aproject/a2a-dotnet/blob/main/docs/migration-guide-v1.md) when upgrading.
-
-## Citations (Microsoft-specific extension)
-
-> **Important:** Citations are delivered via a **Microsoft-specific extension** to the A2A protocol — not part of the [A2A spec](https://a2a-protocol.org). This format is specific to Microsoft 365 Copilot and is subject to change. When WorkIQ moves to its dedicated gateway, citations may be delivered using A2A-native `DataPart` or a formal A2A extension mechanism.
-
-### How citations work in A2A
-
-The standard A2A protocol defines `TextPart`, `FilePart`, and `DataPart` as message parts, but has no built-in citation type. Microsoft 365 Copilot delivers citations via the `AgentMessage.Metadata` dictionary under the key `"attributions"`.
-
-### Citation schema
+Citations are delivered via a **Microsoft-specific extension** to the A2A protocol under `AgentMessage.Metadata["attributions"]`. This is not part of the [A2A spec](https://a2a-protocol.org) and is subject to change.
 
 ```json
-// AgentMessage.Metadata["attributions"]
 [
   {
-    "attributionType": "Citation",          // "Citation" or "Annotation"
-    "attributionSource": "Model",           // "Model" (cited in response) or "Grounding" (used but not cited)
-    "providerDisplayName": "Q3 Planning",   // Display name of the source
-    "seeMoreWebUrl": "https://...",         // Link to the source
-    "imageWebUrl": "",                      // Optional image URL
-    "imageFavIcon": "",                     // Optional favicon
-    "imageWidth": 0,                        // Optional image dimensions
-    "imageHeight": 0
+    "attributionType": "Citation",
+    "attributionSource": "Model",
+    "providerDisplayName": "Q3 Planning Meeting",
+    "seeMoreWebUrl": "https://teams.microsoft.com/..."
   }
 ]
 ```
 
-### Attribution types
+| Type | Meaning |
+|------|---------|
+| `Citation` | Source explicitly referenced in the response text (e.g., `[1]`) |
+| `Annotation` | Entity recognized in the response but not numbered |
 
-| Type | Meaning | Example |
-|------|---------|---------|
-| `Citation` | Source explicitly referenced in the response text (e.g., `[1]`) | A meeting, email, or document |
-| `Annotation` | Entity recognized in the response but not numbered | A person mention, team name |
+Use `-v 2` to see full citation details in the output.
 
-### Attribution sources
-
-| Source | Meaning |
-|--------|---------|
-| `Model` | Used by the model to generate the response (cited) |
-| `Grounding` | Used for context/grounding but not directly cited |
-
-### Parsing in code
+### Parsing citations in code
 
 ```csharp
-// After receiving an AgentMessage (sync or streaming)
 if (agentMessage.Metadata?.TryGetValue("attributions", out var attrs) == true
     && attrs.ValueKind == JsonValueKind.Array)
 {
     foreach (var attr in attrs.EnumerateArray())
     {
-        var type = attr.GetProperty("attributionType").ToString();     // "Citation" or "Annotation"
-        var source = attr.GetProperty("attributionSource").ToString(); // "Model" or "Grounding"
         var name = attr.GetProperty("providerDisplayName").GetString();
         var url = attr.GetProperty("seeMoreWebUrl").GetString();
-        
-        Console.WriteLine($"[{type}] {name} → {url}");
+        Console.WriteLine($"  [{name}] {url}");
     }
 }
 ```
 
-### Sample output (`-v 2`)
+## Wire diagnostics
+
+Use `-v 2` to see full HTTP request/response details:
 
 ```
-Agent > You have 3 meetings scheduled tomorrow...
-  (22500 ms)
-  Citations: 3  Annotations: 2
-    📄 [Citation/Model] Q3 Planning Meeting
-       https://teams.microsoft.com/l/meeting/details?eventId=...
-    📄 [Citation/Model] Weekly Team Standup
-       https://teams.microsoft.com/l/meeting/details?eventId=...
-    🔗 [Annotation/Model] Jane Smith
-       https://www.office.com/search?q=Jane+Smith...
-```
-
-### Future direction
-
-When WorkIQ transitions to its dedicated gateway, citations will likely move to one of:
-1. **A2A `DataPart`** — structured data parts in the message (A2A-native)
-2. **A2A extension** — formal extension mechanism per A2A spec
-3. **Same metadata format** — carried forward for backward compatibility
-
-Monitor the [WorkIQ API documentation](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility) for updates.
-
-## Wire Diagnostics
-
-The sample includes a `WireLog` HTTP handler that prints full request/response diagnostics:
-
-```
-  ▶ POST https://graph.microsoft.com/rp/workiq/
+  > POST https://graph.microsoft.com/rp/workiq/
     Authorization: Bearer ...(3089c)
     Content-Type: application/json
     Body: {"jsonrpc":"2.0","method":"message/send","params":{...}}
 
-  ◀ 200 OK
+  < 200 OK
     request-id: d7d0989c-...
-    Content-Type: application/json
 ```
 
-For errors (4xx/5xx), the full response body is printed in red.
+## NuGet dependencies
+
+| Package | Purpose |
+|---------|---------|
+| [`A2A`](https://www.nuget.org/packages/A2A/) (0.3.3-preview) | A2A protocol client |
+| `Microsoft.Identity.Client` | MSAL token acquisition |
+| `Microsoft.Identity.Client.Broker` | Windows WAM broker |
+| `System.IdentityModel.Tokens.Jwt` | JWT decoding for diagnostics |
+
+> **Note:** This sample uses A2A SDK v0.3.3-preview. The spec has since moved to v1.0. See the [migration guide](https://github.com/a2aproject/a2a-dotnet/blob/main/docs/migration-guide-v1.md) when upgrading.
 
 ## Resources
 
 - [A2A Protocol Specification](https://a2a-protocol.org/latest/specification/)
-- [A2A .NET SDK (GitHub)](https://github.com/a2aproject/a2a-dotnet)
-- [A2A NuGet Package](https://www.nuget.org/packages/A2A/)
-- [Microsoft Graph Copilot Chat API](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat)
-- [WorkIQ CLI](https://github.com/nicholasgasior/work-iq-cli) _(reference implementation)_
+- [A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet)
+- [Work IQ Overview](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/workiq-overview)

--- a/a2a/nuget.config
+++ b/a2a/nuget.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/a2a/workiq-a2a-sample.csproj
+++ b/a2a/workiq-a2a-sample.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>workiq_a2a_sample</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="A2A" Version="0.3.3-preview" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.83.1" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.83.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
+  </ItemGroup>
+
+</Project>

--- a/rest/Program.cs
+++ b/rest/Program.cs
@@ -1,0 +1,481 @@
+// WorkIQ REST Sample — Interactive Copilot Chat via Microsoft Graph REST API
+// Supports both synchronous (/chat) and streaming (/chatOverStream) modes.
+// Usage: dotnet run -- --token <JWT|WAM> --appid <clientId> [--stream] [--account <email>]
+// Docs:  https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview
+
+using System.Diagnostics;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http.Headers;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Client.Broker;
+
+const string GraphBase = "https://graph.microsoft.com/beta/copilot";
+
+var config = ParseArgs(args);
+if (config == null) return;
+
+string token;
+IPublicClientApplication? msalApp = null;
+IAccount? msalAccount = null;
+
+if (config.Token.Equals("WAM", StringComparison.OrdinalIgnoreCase))
+{
+    var r = await AcquireWamToken(config.AppId, config.Account);
+    token = r.token; msalApp = r.app; msalAccount = r.account;
+}
+else
+{
+    token = config.Token;
+}
+
+if (config.Verbosity >= 1)
+{
+    Log("TOKEN");
+    DecodeToken(token);
+    if (config.ShowToken) Console.WriteLine($"\n  {token}\n");
+}
+
+var httpClient = new HttpClient { Timeout = TimeSpan.FromMinutes(5) };
+httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+foreach (var h in config.Headers)
+{
+    var parts = h.Split(':', 2);
+    if (parts.Length == 2) httpClient.DefaultRequestHeaders.TryAddWithoutValidation(parts[0].Trim(), parts[1].Trim());
+}
+
+string? conversationId = null;
+
+if (config.Verbosity >= 1)
+{
+    Log($"READY — {(config.Stream ? "Streaming" : "Synchronous")} mode");
+    Console.WriteLine("Type a message. 'quit' to exit.\n");
+}
+
+while (true)
+{
+    if (config.Verbosity >= 1) Ink("You > ", ConsoleColor.Cyan);
+    var input = Console.ReadLine();
+    if (string.IsNullOrWhiteSpace(input) || input.Equals("quit", StringComparison.OrdinalIgnoreCase)) break;
+
+    // Silent token refresh
+    if (msalApp != null)
+    {
+        try
+        {
+            var r = await AcquireWamToken(config.AppId, config.Account, msalApp, msalAccount);
+            token = r.token; msalAccount = r.account;
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+        catch { /* use cached */ }
+    }
+
+    try
+    {
+        // Step 1: Create conversation (first turn only)
+        if (conversationId == null)
+        {
+            conversationId = await CreateConversation(httpClient);
+            if (config.Verbosity >= 1) Ink($"  Conversation: {conversationId}\n", ConsoleColor.DarkGray);
+        }
+
+        // Step 2: Send message
+        var sw = Stopwatch.StartNew();
+        if (config.Stream)
+        {
+            await ChatStream(httpClient, conversationId, input);
+        }
+        else
+        {
+            await ChatSync(httpClient, conversationId, input);
+        }
+
+        sw.Stop();
+        if (config.Verbosity >= 1) Ink($"  ({sw.ElapsedMilliseconds} ms)\n", ConsoleColor.DarkGray);
+    }
+    catch (Exception ex)
+    {
+        Ink($"\n  ERROR: {ex.GetType().Name}: {ex.Message}\n", ConsoleColor.Red);
+        if (ex.InnerException != null) Ink($"  INNER: {ex.InnerException.Message}\n", ConsoleColor.Red);
+        conversationId = null; // Reset conversation on error
+    }
+
+    Console.WriteLine();
+}
+
+// ── API calls ────────────────────────────────────────────────────────────
+
+async Task<string> CreateConversation(HttpClient client)
+{
+    if (config.Verbosity >= 1) Ink("  Creating conversation...\n", ConsoleColor.DarkGray);
+    var response = await client.PostAsync($"{GraphBase}/conversations",
+        new StringContent("{}", Encoding.UTF8, "application/json"));
+
+    var json = await response.Content.ReadAsStringAsync();
+    if (config.Verbosity >= 2) LogWire("POST", $"{GraphBase}/conversations", "{}", response, json);
+
+    response.EnsureSuccessStatusCode();
+
+    using var doc = JsonDocument.Parse(json);
+    return doc.RootElement.GetProperty("id").GetString()
+        ?? throw new InvalidOperationException("No conversation ID in response");
+}
+
+async Task ChatSync(HttpClient client, string convId, string message)
+{
+    var url = $"{GraphBase}/conversations/{convId}/chat";
+    var body = BuildChatBody(message);
+
+    var response = await client.PostAsync(url, new StringContent(body, Encoding.UTF8, "application/json"));
+    var json = await response.Content.ReadAsStringAsync();
+    if (config.Verbosity >= 2) LogWire("POST", url, body, response, json);
+
+    response.EnsureSuccessStatusCode();
+
+    using var doc = JsonDocument.Parse(json);
+    var messages = doc.RootElement.GetProperty("messages");
+
+    // Last message is the assistant response
+    JsonElement lastMsg = default;
+    foreach (var msg in messages.EnumerateArray()) lastMsg = msg;
+
+    var text = lastMsg.GetProperty("text").GetString() ?? "";
+    if (config.Verbosity >= 1) Ink("Agent > ", ConsoleColor.Green);
+    Console.WriteLine(text);
+
+    // Parse and display citations
+    if (lastMsg.TryGetProperty("attributions", out var attrs) && attrs.GetArrayLength() > 0)
+    {
+        PrintCitations(attrs);
+    }
+}
+
+void PrintCitations(JsonElement attrs)
+{
+    var citations = new List<(string type, string source, string provider, string url)>();
+    foreach (var attr in attrs.EnumerateArray())
+    {
+        var type = attr.TryGetProperty("attributionType", out var t) ? t.GetString() ?? "" : "";
+        var source = attr.TryGetProperty("attributionSource", out var s) ? s.GetString() ?? "" : "";
+        var provider = attr.TryGetProperty("providerDisplayName", out var p) ? p.GetString() ?? "" : "";
+        var url = attr.TryGetProperty("seeMoreWebUrl", out var u) ? u.GetString() ?? "" : "";
+        citations.Add((type, source, provider, url));
+    }
+
+    var citationCount = citations.Count(c => c.type == "citation");
+    var annotationCount = citations.Count(c => c.type == "annotation");
+
+    if (config.Verbosity >= 1)
+    {
+        Ink($"\n  Citations: {citationCount}  Annotations: {annotationCount}\n", ConsoleColor.DarkYellow);
+    }
+
+    if (config.Verbosity >= 2)
+    {
+        foreach (var (type, source, provider, url) in citations)
+        {
+            var label = type == "citation" ? "📄" : "🔗";
+            var name = !string.IsNullOrEmpty(provider) ? provider : "(unnamed)";
+            Console.ForegroundColor = type == "citation" ? ConsoleColor.Yellow : ConsoleColor.DarkGray;
+            Console.WriteLine($"    {label} [{type}/{source}] {name}");
+            if (!string.IsNullOrEmpty(url))
+            {
+                Console.ForegroundColor = ConsoleColor.DarkGray;
+                Console.WriteLine($"       {Trunc(url, 120)}");
+            }
+        }
+
+        Console.ResetColor();
+    }
+}
+
+async Task ChatStream(HttpClient client, string convId, string message)
+{
+    var url = $"{GraphBase}/conversations/{convId}/chatOverStream";
+    var body = BuildChatBody(message);
+
+    var request = new HttpRequestMessage(HttpMethod.Post, url)
+    {
+        Content = new StringContent(body, Encoding.UTF8, "application/json"),
+    };
+
+    var response = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+    if (config.Verbosity >= 2) LogWire("POST", url, body, response);
+
+    response.EnsureSuccessStatusCode();
+
+    using var stream = await response.Content.ReadAsStreamAsync();
+    using var reader = new StreamReader(stream);
+
+    string? previousText = null;
+    bool headerPrinted = false;
+    JsonElement lastAttrs = default;
+    bool hasAttrs = false;
+
+    while (!reader.EndOfStream)
+    {
+        var line = await reader.ReadLineAsync();
+        if (line == null) break;
+
+        // SSE format: "data: {...}"
+        if (!line.StartsWith("data: ")) continue;
+        var eventJson = line["data: ".Length..];
+        if (string.IsNullOrWhiteSpace(eventJson)) continue;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(eventJson);
+            var root = doc.RootElement;
+
+            if (!root.TryGetProperty("messages", out var msgs)) continue;
+
+            // Find the latest assistant message
+            JsonElement lastMsg = default;
+            bool found = false;
+            foreach (var msg in msgs.EnumerateArray())
+            {
+                if (msg.TryGetProperty("text", out _))
+                {
+                    lastMsg = msg;
+                    found = true;
+                }
+            }
+
+            if (!found) continue;
+
+            var text = lastMsg.GetProperty("text").GetString() ?? "";
+
+            // Track citations from latest event (final event has complete attributions)
+            if (lastMsg.TryGetProperty("attributions", out var a) && a.GetArrayLength() > 0)
+            {
+                lastAttrs = a.Clone();
+                hasAttrs = true;
+            }
+
+            // Print only the delta (new text since last event)
+            if (!headerPrinted) { if (config.Verbosity >= 1) Ink("Agent > ", ConsoleColor.Green); headerPrinted = true; }
+
+            if (previousText != null && text.StartsWith(previousText))
+            {
+                Console.Write(text[previousText.Length..]);
+            }
+            else if (previousText == null || text != previousText)
+            {
+                Console.Write(text);
+            }
+
+            previousText = text;
+        }
+        catch (JsonException)
+        {
+            // Skip malformed events
+        }
+    }
+
+    Console.WriteLine();
+
+    // Print citations from the final SSE event
+    if (hasAttrs)
+    {
+        PrintCitations(lastAttrs);
+    }
+}
+
+static string BuildChatBody(string message)
+{
+    // Graph API requires IANA timezone (e.g. "America/Los_Angeles"), not Windows (e.g. "Pacific Standard Time")
+    string tz;
+    try { tz = TimeZoneInfo.Local.HasIanaId ? TimeZoneInfo.Local.Id : TimeZoneInfo.TryConvertWindowsIdToIanaId(TimeZoneInfo.Local.Id, out var iana) ? iana : "UTC"; }
+    catch { tz = "UTC"; }
+
+    return JsonSerializer.Serialize(new
+    {
+        message = new { text = message },
+        locationHint = new { timeZone = tz },
+    });
+}
+
+// ── WAM auth ─────────────────────────────────────────────────────────────
+
+static async Task<(string token, IPublicClientApplication app, IAccount? account)> AcquireWamToken(
+    string clientId, string? accountHint,
+    IPublicClientApplication? existingApp = null, IAccount? existingAccount = null)
+{
+    var app = existingApp;
+    if (app == null)
+    {
+        var builder = PublicClientApplicationBuilder.Create(clientId)
+            .WithDefaultRedirectUri()
+            .WithAuthority("https://login.microsoftonline.com/common");
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            builder.WithParentActivityOrWindow(ConsoleWindowHandle).WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows));
+        }
+
+        app = builder.Build();
+    }
+
+    string[] scopes = ["https://graph.microsoft.com/.default"];
+    AuthenticationResult result;
+
+    try
+    {
+        if (existingAccount != null)
+        {
+            result = await app.AcquireTokenSilent(scopes, existingAccount).ExecuteAsync();
+        }
+        else if (!string.IsNullOrEmpty(accountHint))
+        {
+            var cached = (await app.GetAccountsAsync()).FirstOrDefault(a => a.Username?.Contains(accountHint, StringComparison.OrdinalIgnoreCase) == true);
+            result = cached != null
+                ? await app.AcquireTokenSilent(scopes, cached).ExecuteAsync()
+                : await app.AcquireTokenInteractive(scopes).WithLoginHint(accountHint).ExecuteAsync();
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            result = await app.AcquireTokenSilent(scopes, PublicClientApplication.OperatingSystemAccount).ExecuteAsync();
+        }
+        else
+        {
+            result = await app.AcquireTokenInteractive(scopes).ExecuteAsync();
+        }
+    }
+    catch (MsalUiRequiredException)
+    {
+        result = await app.AcquireTokenInteractive(scopes).ExecuteAsync();
+    }
+
+    return (result.AccessToken, app, result.Account);
+}
+
+// ── Token decode ─────────────────────────────────────────────────────────
+
+static void DecodeToken(string token)
+{
+    try
+    {
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(token);
+        foreach (var c in new[] { "aud", "appid", "app_displayname", "tid", "upn", "name", "scp" })
+        {
+            var v = jwt.Claims.FirstOrDefault(x => x.Type == c)?.Value;
+            if (!string.IsNullOrEmpty(v)) Console.WriteLine($"  {c,-16} {v}");
+        }
+
+        var left = jwt.ValidTo - DateTime.UtcNow;
+        Ink($"  {"expires",-16} {jwt.ValidTo:HH:mm:ss} UTC ({(left.TotalMinutes > 0 ? $"{left.TotalMinutes:F0}m" : "EXPIRED")})\n",
+            left.TotalMinutes < 5 ? ConsoleColor.Red : ConsoleColor.Gray);
+    }
+    catch (Exception ex) { Ink($"  decode failed: {ex.Message}\n", ConsoleColor.Red); }
+}
+
+// ── Args ─────────────────────────────────────────────────────────────────
+
+static Config? ParseArgs(string[] args)
+{
+    string? token = null, appId = null, account = null;
+    bool graph = false, workiq = false, stream = false, showToken = false;
+    int verbosity = 1;
+    var headers = new List<string>();
+
+    for (int i = 0; i < args.Length; i++)
+    {
+        switch (args[i])
+        {
+            case "--graph": graph = true; break;
+            case "--workiq": workiq = true; break;
+            case "--token" or "-t": token = args[++i]; break;
+            case "--appid" or "-a": appId = args[++i]; break;
+            case "--account": account = args[++i]; break;
+            case "--stream": stream = true; break;
+            case "--show-token": showToken = true; break;
+            case "--verbosity" or "-v": verbosity = int.Parse(args[++i]); break;
+            case "--header" or "-H": headers.Add(args[++i]); break;
+        }
+    }
+
+    if (string.IsNullOrEmpty(token) || (!graph && !workiq))
+    {
+        Console.WriteLine("""
+            WorkIQ REST Sample — Interactive Copilot Chat via Microsoft Graph
+
+            Usage: dotnet run -- <gateway> --token <JWT|WAM> --appid <clientId> [options]
+
+            Gateway (exactly one required):
+              --graph          Use Microsoft Graph API
+              --workiq         Use WorkIQ Gateway (coming soon)
+
+            Auth:
+              --token, -t      Bearer token or 'WAM' for Windows broker auth
+              --appid, -a      App client ID (required with WAM)
+              --account        Account hint (e.g. user@contoso.com)
+
+            Options:
+              --header, -H     Custom HTTP header in 'Key: Value' format (repeatable)
+              --stream         Use streaming mode (SSE via /chatOverStream)
+              --show-token     Print the raw JWT token (for reuse)
+              -v, --verbosity  0 = response only, 1 = default, 2 = full wire
+
+            Examples:
+              dotnet run -- --graph --token WAM --appid <your-app-id>
+              dotnet run -- --graph --token WAM --appid <your-app-id> --stream
+              dotnet run -- --graph --token eyJ0eXAi...
+            """);
+        return null;
+    }
+
+    if (graph && workiq)
+    {
+        Ink("ERROR: specify --graph or --workiq, not both\n", ConsoleColor.Red);
+        return null;
+    }
+
+    if (workiq)
+    {
+        Ink("ERROR: --workiq gateway is not yet implemented\n", ConsoleColor.Yellow);
+        return null;
+    }
+
+    if (token.Equals("WAM", StringComparison.OrdinalIgnoreCase) && string.IsNullOrEmpty(appId))
+    {
+        Ink("ERROR: --appid is required when using --token WAM\n", ConsoleColor.Red);
+        return null;
+    }
+
+    return new Config(token, appId ?? "", account, stream, showToken, verbosity, headers);
+}
+
+// ── Utilities ────────────────────────────────────────────────────────────
+
+static void Log(string s) { Ink($"\n── {s} ──\n", ConsoleColor.DarkGray); }
+static void Ink(string s, ConsoleColor c) { Console.ForegroundColor = c; Console.Write(s); Console.ResetColor(); }
+
+static void LogWire(string method, string url, string? body, HttpResponseMessage res, string? responseBody = null)
+{
+    Console.ForegroundColor = ConsoleColor.DarkGray;
+    Console.WriteLine($"  ▶ {method} {url}");
+    foreach (var h in res.RequestMessage?.Headers ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>())
+        Console.WriteLine($"    {h.Key}: {string.Join(", ", h.Value)}");
+    if (body != null && body.Length > 2) Console.WriteLine($"    Body: {Trunc(body, 300)}");
+
+    Console.ForegroundColor = (int)res.StatusCode >= 400 ? ConsoleColor.Red : ConsoleColor.DarkGray;
+    Console.WriteLine($"  ◀ {(int)res.StatusCode} {res.StatusCode}");
+    foreach (var h in res.Headers) Console.WriteLine($"    {h.Key}: {string.Join(", ", h.Value)}");
+    if (res.Content != null)
+        foreach (var h in res.Content.Headers) Console.WriteLine($"    {h.Key}: {string.Join(", ", h.Value)}");
+
+    if ((int)res.StatusCode >= 400 && responseBody != null)
+        Console.WriteLine($"    {Trunc(responseBody, 500)}");
+
+    Console.ResetColor();
+}
+
+static string Trunc(string s, int max) => s.Length <= max ? s : $"{s[..max]}...";
+
+[DllImport("kernel32.dll", EntryPoint = "GetConsoleWindow")] static extern IntPtr Win32GetConsoleWindow();
+[DllImport("user32.dll", ExactSpelling = true)] static extern IntPtr GetAncestor(IntPtr hwnd, uint flags);
+static IntPtr ConsoleWindowHandle() { var c = Win32GetConsoleWindow(); var r = GetAncestor(c, 3); return r != IntPtr.Zero ? r : c; }
+
+record Config(string Token, string AppId, string? Account, bool Stream, bool ShowToken, int Verbosity, List<string> Headers);

--- a/rest/README.md
+++ b/rest/README.md
@@ -1,0 +1,184 @@
+# WorkIQ REST Sample
+
+A minimal, single-file interactive client for the [Microsoft 365 Copilot Chat API](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview) — the REST interface for conversational AI grounded in Microsoft 365 data.
+
+Supports both **synchronous** and **streaming** (SSE) modes.
+
+> **Preview (via Microsoft Graph):** During preview, WorkIQ is accessed through the Microsoft Graph API at `graph.microsoft.com`. When WorkIQ's dedicated infrastructure is available, the endpoint will move to `workiq.svc.cloud.dev.microsoft` with its own app registration (audience: `fdcc1f02-fc51-4226-8753-f668596af7f7`) and scopes. The code and instructions in this sample will be updated at that time.
+
+## API Reference
+
+| Operation | Method | Endpoint | Docs |
+|-----------|--------|----------|------|
+| Create conversation | `POST` | `/beta/copilot/conversations` | [Docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotroot-post-conversations) |
+| Chat (sync) | `POST` | `/beta/copilot/conversations/{id}/chat` | [Docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat) |
+| Chat (stream) | `POST` | `/beta/copilot/conversations/{id}/chatOverStream` | [Docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chatoverstream) |
+
+## Prerequisites
+
+- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
+- A [Microsoft 365 Copilot license](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview#licensing)
+- An Azure AD app registration with **all 7** delegated permissions:
+
+| Permission | Description |
+|-----------|-------------|
+| `Sites.Read.All` | Read SharePoint sites |
+| `Mail.Read` | Read user mail |
+| `People.Read.All` | Read people data |
+| `OnlineMeetingTranscript.Read.All` | Read meeting transcripts |
+| `Chat.Read` | Read Teams chats |
+| `ChannelMessage.Read.All` | Read Teams channel messages |
+| `ExternalItem.Read.All` | Read external connector items |
+
+> All seven are required. See [permissions docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat#permissions).
+
+## Usage
+
+```bash
+# Build
+dotnet build
+
+# Synchronous mode (default) — full response in one JSON payload
+dotnet run -- --token WAM --appid <your-app-id>
+
+# Streaming mode — incremental response via Server-Sent Events
+dotnet run -- --token WAM --appid <your-app-id> --stream
+
+# With account hint (skips account picker)
+dotnet run -- --token WAM --appid <your-app-id> --account user@contoso.com
+
+# With a pre-obtained JWT token
+dotnet run -- --token eyJ0eXAi...
+
+# Print token for reuse
+dotnet run -- --token WAM --appid <your-app-id> --show-token
+```
+
+### Parameters
+
+| Flag | Description |
+|------|-------------|
+| `--token`, `-t` | Bearer JWT token, or `WAM` for Windows broker auth |
+| `--appid`, `-a` | Azure AD app client ID (required with `--token WAM`) |
+| `--account` | Account hint for WAM (e.g. `user@contoso.com`) |
+| `--stream` | Use streaming mode (`/chatOverStream` with SSE) |
+| `--show-token` | Print the raw JWT after decoding |
+
+## How It Works
+
+### Synchronous Mode (default)
+
+```
+Client                          Microsoft Graph
+  │                                   │
+  ├── POST /beta/copilot/conversations ──►  (creates conversation)
+  │◄── 201 { "id": "conv-123" } ──────┤
+  │                                   │
+  ├── POST .../conversations/conv-123/chat ──►
+  │    { "message": { "text": "..." },      │
+  │      "locationHint": { "timeZone": "..." } }
+  │◄── 200 { "messages": [...] } ──────┤
+  │    (complete response)             │
+```
+
+### Streaming Mode (`--stream`)
+
+```
+Client                          Microsoft Graph
+  │                                   │
+  ├── POST /beta/copilot/conversations ──►
+  │◄── 201 { "id": "conv-123" } ──────┤
+  │                                   │
+  ├── POST .../conversations/conv-123/chatOverStream ──►
+  │◄── 200 text/event-stream ─────────┤
+  │    data: { "messages": [...] }     │  (partial)
+  │    data: { "messages": [...] }     │  (more text)
+  │    data: { "messages": [...] }     │  (complete)
+  │                                   │
+```
+
+Each SSE `data:` event contains the full conversation state. The sample computes deltas to print only new text as it arrives.
+
+## Multi-Turn Conversations
+
+The sample reuses the conversation ID across turns. Each message you type continues the same conversation with full context:
+
+```
+You > What meetings do I have tomorrow?
+Agent > You have 3 meetings scheduled...
+
+You > Which one has the most attendees?
+Agent > The "Q3 Planning" meeting has 12 attendees...
+```
+
+If an error occurs, the conversation is reset and a new one is created on the next message.
+
+## Request/Response Format
+
+### Request Body (`/chat` and `/chatOverStream`)
+
+```json
+{
+  "message": { "text": "What meetings do I have tomorrow?" },
+  "locationHint": { "timeZone": "America/Los_Angeles" }
+}
+```
+
+### Response (`/chat` — synchronous)
+
+```json
+{
+  "id": "conv-123",
+  "state": "active",
+  "messages": [
+    { "text": "What meetings do I have tomorrow?", ... },
+    { "text": "You have 3 meetings...", "attributions": [...], ... }
+  ]
+}
+```
+
+### Response (`/chatOverStream` — SSE)
+
+```
+data: { "id": "conv-123", "messages": [{ "text": "You have" }] }
+data: { "id": "conv-123", "messages": [{ "text": "You have 3 meetings" }] }
+data: { "id": "conv-123", "messages": [{ "text": "You have 3 meetings scheduled..." }] }
+```
+
+## Gotchas
+
+### No external NuGet dependencies for the API
+Unlike the A2A sample (which uses the `A2A` NuGet SDK), this sample calls the Graph REST API directly with `HttpClient`. No SDK needed — just JSON over HTTP.
+
+### Token audience must be `https://graph.microsoft.com`
+The Chat API is a native Microsoft Graph API. Tokens must have `aud: https://graph.microsoft.com`.
+
+### Streaming response is cumulative, not incremental
+Each SSE event contains the **full** conversation state (all messages, full text). The sample computes deltas by comparing with the previous event's text. This is different from typical LLM streaming where each chunk is incremental.
+
+### Conversation state is "active" during streaming
+The `state` field in SSE events is `active` while tokens are still being generated. The final event has the complete response.
+
+### Graph Explorer doesn't support streaming
+Per [Microsoft docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview#known-limitations), Graph Explorer doesn't support streamed conversations. Use this sample or curl instead.
+
+### Platform support
+
+| Platform | Auth method | Status |
+|----------|------------|--------|
+| **Windows** | WAM broker (silent SSO) | ✅ Tested |
+| **macOS** | Interactive browser login | 🔄 Untested (should work) |
+| **Linux / WSL** | Interactive browser login | 🔄 Untested (should work) |
+
+On Windows, `--token WAM` uses the Windows Account Manager for silent SSO. On macOS/Linux, MSAL falls back to interactive browser authentication. You can also use `--token <JWT>` on any platform with a pre-obtained token.
+
+### Token caching
+Tokens are held **in memory only** for the duration of the session — they are not persisted to disk. Each run requires a fresh authentication. For production applications, consider using [MSAL token cache serialization](https://learn.microsoft.com/en-us/entra/msal/dotnet/how-to/token-cache-serialization) with platform-appropriate encryption (DPAPI on Windows, Keychain on macOS, keyring on Linux).
+
+## Resources
+
+- [Chat API Overview](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview)
+- [Create Conversation](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotroot-post-conversations)
+- [Chat (sync)](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat)
+- [Chat Over Stream (SSE)](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chatoverstream)
+- [Permissions Reference](https://learn.microsoft.com/en-us/graph/permissions-reference)

--- a/rest/README.md
+++ b/rest/README.md
@@ -1,12 +1,12 @@
-# WorkIQ REST Sample
+# Work IQ REST Sample
 
 A minimal, single-file interactive client for the [Microsoft 365 Copilot Chat API](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview) — the REST interface for conversational AI grounded in Microsoft 365 data.
 
 Supports both **synchronous** and **streaming** (SSE) modes.
 
-> **Preview (via Microsoft Graph):** During preview, WorkIQ is accessed through the Microsoft Graph API at `graph.microsoft.com`. When WorkIQ's dedicated infrastructure is available, the endpoint will move to `workiq.svc.cloud.dev.microsoft` with its own app registration (audience: `fdcc1f02-fc51-4226-8753-f668596af7f7`) and scopes. The code and instructions in this sample will be updated at that time.
+> **Prerequisites, authentication, and common issues** are covered in the [root README](../README.md). Read that first.
 
-## API Reference
+## API reference
 
 | Operation | Method | Endpoint | Docs |
 |-----------|--------|----------|------|
@@ -14,47 +14,23 @@ Supports both **synchronous** and **streaming** (SSE) modes.
 | Chat (sync) | `POST` | `/beta/copilot/conversations/{id}/chat` | [Docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat) |
 | Chat (stream) | `POST` | `/beta/copilot/conversations/{id}/chatOverStream` | [Docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chatoverstream) |
 
-## Prerequisites
-
-- [.NET 8.0 SDK](https://dotnet.microsoft.com/download/dotnet/8.0) or later
-- A [Microsoft 365 Copilot license](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview#licensing)
-- An Azure AD app registration with **all 7** delegated permissions:
-
-| Permission | Description |
-|-----------|-------------|
-| `Sites.Read.All` | Read SharePoint sites |
-| `Mail.Read` | Read user mail |
-| `People.Read.All` | Read people data |
-| `OnlineMeetingTranscript.Read.All` | Read meeting transcripts |
-| `Chat.Read` | Read Teams chats |
-| `ChannelMessage.Read.All` | Read Teams channel messages |
-| `ExternalItem.Read.All` | Read external connector items |
-
-> All seven are required. See [permissions docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat#permissions).
-
-## Usage
+## Quick start
 
 ```bash
 # Build
 dotnet build
 
-# Synchronous mode (default) — full response in one JSON payload
-dotnet run -- --token WAM --appid <your-app-id>
+# Synchronous mode (default)
+dotnet run -- --token WAM --appid <your-app-client-id>
 
-# Streaming mode — incremental response via Server-Sent Events
-dotnet run -- --token WAM --appid <your-app-id> --stream
+# Streaming mode (SSE)
+dotnet run -- --token WAM --appid <your-app-client-id> --stream
 
-# With account hint (skips account picker)
-dotnet run -- --token WAM --appid <your-app-id> --account user@contoso.com
-
-# With a pre-obtained JWT token
-dotnet run -- --token eyJ0eXAi...
-
-# Print token for reuse
-dotnet run -- --token WAM --appid <your-app-id> --show-token
+# With account hint
+dotnet run -- --token WAM --appid <your-app-client-id> --account user@contoso.com
 ```
 
-### Parameters
+## Parameters
 
 | Flag | Description |
 |------|-------------|
@@ -64,44 +40,41 @@ dotnet run -- --token WAM --appid <your-app-id> --show-token
 | `--stream` | Use streaming mode (`/chatOverStream` with SSE) |
 | `--show-token` | Print the raw JWT after decoding |
 
-## How It Works
+## How it works
 
-### Synchronous Mode (default)
-
-```
-Client                          Microsoft Graph
-  │                                   │
-  ├── POST /beta/copilot/conversations ──►  (creates conversation)
-  │◄── 201 { "id": "conv-123" } ──────┤
-  │                                   │
-  ├── POST .../conversations/conv-123/chat ──►
-  │    { "message": { "text": "..." },      │
-  │      "locationHint": { "timeZone": "..." } }
-  │◄── 200 { "messages": [...] } ──────┤
-  │    (complete response)             │
-```
-
-### Streaming Mode (`--stream`)
+### Synchronous mode (default)
 
 ```
-Client                          Microsoft Graph
-  │                                   │
-  ├── POST /beta/copilot/conversations ──►
-  │◄── 201 { "id": "conv-123" } ──────┤
-  │                                   │
-  ├── POST .../conversations/conv-123/chatOverStream ──►
-  │◄── 200 text/event-stream ─────────┤
-  │    data: { "messages": [...] }     │  (partial)
-  │    data: { "messages": [...] }     │  (more text)
-  │    data: { "messages": [...] }     │  (complete)
-  │                                   │
+Client                              Microsoft Graph
+  |                                       |
+  |-- POST /beta/copilot/conversations -->|  (creates conversation)
+  |<-- 201 { "id": "conv-123" } ---------|
+  |                                       |
+  |-- POST .../conv-123/chat ------------>|
+  |   { "message": { "text": "..." } }   |
+  |<-- 200 { "messages": [...] } ---------|  (complete response)
 ```
 
-Each SSE `data:` event contains the full conversation state. The sample computes deltas to print only new text as it arrives.
+### Streaming mode (`--stream`)
 
-## Multi-Turn Conversations
+```
+Client                              Microsoft Graph
+  |                                       |
+  |-- POST /beta/copilot/conversations -->|
+  |<-- 201 { "id": "conv-123" } ---------|
+  |                                       |
+  |-- POST .../conv-123/chatOverStream -->|
+  |<-- 200 text/event-stream -------------|
+  |    data: { "messages": [...] }        |  (partial)
+  |    data: { "messages": [...] }        |  (more text)
+  |    data: { "messages": [...] }        |  (complete)
+```
 
-The sample reuses the conversation ID across turns. Each message you type continues the same conversation with full context:
+Each SSE event contains the **full conversation state** (cumulative, not incremental). The sample computes deltas by comparing with the previous event's text to print only new content as it arrives.
+
+## Multi-turn conversations
+
+The sample reuses the conversation ID across turns. Each message continues the same conversation with full context:
 
 ```
 You > What meetings do I have tomorrow?
@@ -111,11 +84,9 @@ You > Which one has the most attendees?
 Agent > The "Q3 Planning" meeting has 12 attendees...
 ```
 
-If an error occurs, the conversation is reset and a new one is created on the next message.
+## Request/response format
 
-## Request/Response Format
-
-### Request Body (`/chat` and `/chatOverStream`)
+### Request body
 
 ```json
 {
@@ -124,20 +95,20 @@ If an error occurs, the conversation is reset and a new one is created on the ne
 }
 ```
 
-### Response (`/chat` — synchronous)
+### Sync response
 
 ```json
 {
   "id": "conv-123",
   "state": "active",
   "messages": [
-    { "text": "What meetings do I have tomorrow?", ... },
-    { "text": "You have 3 meetings...", "attributions": [...], ... }
+    { "text": "What meetings do I have tomorrow?" },
+    { "text": "You have 3 meetings...", "attributions": [...] }
   ]
 }
 ```
 
-### Response (`/chatOverStream` — SSE)
+### Streaming response (SSE)
 
 ```
 data: { "id": "conv-123", "messages": [{ "text": "You have" }] }
@@ -145,35 +116,22 @@ data: { "id": "conv-123", "messages": [{ "text": "You have 3 meetings" }] }
 data: { "id": "conv-123", "messages": [{ "text": "You have 3 meetings scheduled..." }] }
 ```
 
-## Gotchas
+## REST-specific notes
 
-### No external NuGet dependencies for the API
-Unlike the A2A sample (which uses the `A2A` NuGet SDK), this sample calls the Graph REST API directly with `HttpClient`. No SDK needed — just JSON over HTTP.
+- **No external SDK required.** Unlike the A2A sample, this calls the Graph REST API directly with `HttpClient`. Just JSON over HTTP.
+- **Streaming is cumulative, not incremental.** Each SSE event contains the full conversation state. The sample computes deltas by diffing against the previous text.
+- **Conversation state is `active` during streaming.** The `state` field transitions to `active` while tokens are being generated.
+- **Graph Explorer doesn't support streaming.** Per [Microsoft docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview#known-limitations), use this sample or curl instead.
 
-### Token audience must be `https://graph.microsoft.com`
-The Chat API is a native Microsoft Graph API. Tokens must have `aud: https://graph.microsoft.com`.
+## NuGet dependencies
 
-### Streaming response is cumulative, not incremental
-Each SSE event contains the **full** conversation state (all messages, full text). The sample computes deltas by comparing with the previous event's text. This is different from typical LLM streaming where each chunk is incremental.
+| Package | Purpose |
+|---------|---------|
+| `Microsoft.Identity.Client` | MSAL token acquisition |
+| `Microsoft.Identity.Client.Broker` | Windows WAM broker |
+| `System.IdentityModel.Tokens.Jwt` | JWT decoding for diagnostics |
 
-### Conversation state is "active" during streaming
-The `state` field in SSE events is `active` while tokens are still being generated. The final event has the complete response.
-
-### Graph Explorer doesn't support streaming
-Per [Microsoft docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview#known-limitations), Graph Explorer doesn't support streamed conversations. Use this sample or curl instead.
-
-### Platform support
-
-| Platform | Auth method | Status |
-|----------|------------|--------|
-| **Windows** | WAM broker (silent SSO) | ✅ Tested |
-| **macOS** | Interactive browser login | 🔄 Untested (should work) |
-| **Linux / WSL** | Interactive browser login | 🔄 Untested (should work) |
-
-On Windows, `--token WAM` uses the Windows Account Manager for silent SSO. On macOS/Linux, MSAL falls back to interactive browser authentication. You can also use `--token <JWT>` on any platform with a pre-obtained token.
-
-### Token caching
-Tokens are held **in memory only** for the duration of the session — they are not persisted to disk. Each run requires a fresh authentication. For production applications, consider using [MSAL token cache serialization](https://learn.microsoft.com/en-us/entra/msal/dotnet/how-to/token-cache-serialization) with platform-appropriate encryption (DPAPI on Windows, Keychain on macOS, keyring on Linux).
+No A2A SDK or Graph SDK needed — pure `HttpClient` + JSON.
 
 ## Resources
 
@@ -181,4 +139,4 @@ Tokens are held **in memory only** for the duration of the session — they are 
 - [Create Conversation](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotroot-post-conversations)
 - [Chat (sync)](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat)
 - [Chat Over Stream (SSE)](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chatoverstream)
-- [Permissions Reference](https://learn.microsoft.com/en-us/graph/permissions-reference)
+- [Work IQ Overview](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/workiq-overview)

--- a/rest/workiq-rest-sample.csproj
+++ b/rest/workiq-rest-sample.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>workiq_rest_sample</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.83.1" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.83.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.16.0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
 ## Summary
  - **rest/**: REST API client with sync and streaming (SSE) modes via `/beta/copilot/conversations` endpoints
  - **a2a/**: A2A protocol client using the A2A .NET SDK with sync and streaming, multi-turn support, and citation parsing

  Both samples support WAM broker auth (Windows) and pre-obtained JWT tokens. Currently configured for Microsoft Graph gateway (preview).
   Will update to WorkIQ dedicated gateway when available.

  ## What's included
  - Single-file `Program.cs` for each sample (minimal, easy to follow)
  - Comprehensive `README.md` with usage, gotchas, platform support, citation parsing
  - Preview notice: currently uses `graph.microsoft.com` + Graph scopes; will move to `workiq.svc.cloud.dev.microsoft` when ready

  ## Test plan
  - [x] REST sync mode tested against Microsoft Graph
  - [x] REST streaming mode tested against Microsoft Graph
  - [x] A2A sync mode tested against Microsoft Graph RP
  - [x] A2A streaming mode tested against Microsoft Graph RP
  - [x] WAM auth tested on Windows
  - [x] No internal details, feature flags, or debug patterns in code or docs