### PR TITLE
Fix missing Graph permissions, stale token fallback, and wire logger

### DIFF
--- a/dotnet/a2a/Program.cs
+++ b/dotnet/a2a/Program.cs
@@ -449,6 +449,9 @@ class WireLog : DelegatingHandler
                 foreach (var h in body.Headers) Console.WriteLine($"    {h.Key}: {string.Join(", ", h.Value)}");
                 var text = await body.ReadAsStringAsync(ct);
                 Console.WriteLine($"    Body: {Trunc(text, 500)}");
+                // Re-create content so the stream can be read again by SendAsync
+                var newContent = new StringContent(text, System.Text.Encoding.UTF8, body.Headers.ContentType?.MediaType ?? "application/json");
+                req.Content = newContent;
             }
 
             Console.ResetColor();

--- a/rust/a2a/setup-app-registration.ps1
+++ b/rust/a2a/setup-app-registration.ps1
@@ -13,7 +13,14 @@ $GraphApi = "00000003-0000-0000-c000-000000000000"
 
 # Microsoft Graph delegated permission GUIDs
 $Permissions = @{
-    "User.Read" = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
+    "User.Read"                        = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
+    "Sites.Read.All"                   = "205e70e5-aba6-4c52-a976-6d2d46c48043"
+    "Mail.Read"                        = "570282fd-fa5c-430d-a7fd-fc8dc98a9dca"
+    "People.Read.All"                  = "b89f9189-71a5-4e70-b041-9887f0bc7e4a"
+    "OnlineMeetingTranscript.Read.All" = "30b87d18-ebb1-45db-97f8-82ccb1f0190c"
+    "Chat.Read"                        = "f501c180-9344-439a-bca0-6cbf209fd270"
+    "ChannelMessage.Read.All"          = "767156cb-16ae-4d10-8f8b-41b657c8c8c8"
+    "ExternalItem.Read.All"            = "922f9392-b1b7-483c-a4be-0089be7704fb"
 }
 
 Write-Host "── Creating app registration: $DisplayName ──"
@@ -48,7 +55,7 @@ $AppSpId = az ad sp show --id $AppId --query id -o tsv
 
 az rest --method POST `
     --uri "https://graph.microsoft.com/v1.0/oauth2PermissionGrants" `
-    --body "{`"clientId`":`"$AppSpId`",`"consentType`":`"AllPrincipals`",`"resourceId`":`"$GraphSpId`",`"scope`":`"User.Read`"}" `
+    --body "{`"clientId`":`"$AppSpId`",`"consentType`":`"AllPrincipals`",`"resourceId`":`"$GraphSpId`",`"scope`":`"User.Read Sites.Read.All Mail.Read People.Read.All OnlineMeetingTranscript.Read.All Chat.Read ChannelMessage.Read.All ExternalItem.Read.All`"}" `
     -o none
 
 Write-Host ""

--- a/rust/a2a/setup-app-registration.sh
+++ b/rust/a2a/setup-app-registration.sh
@@ -14,6 +14,13 @@ GRAPH_API="00000003-0000-0000-c000-000000000000"
 
 # Microsoft Graph delegated permission GUIDs
 USER_READ="e1fe6dd8-ba31-4d61-89e7-88639da4683d"
+SITES_READ_ALL="205e70e5-aba6-4c52-a976-6d2d46c48043"
+MAIL_READ="570282fd-fa5c-430d-a7fd-fc8dc98a9dca"
+PEOPLE_READ_ALL="b89f9189-71a5-4e70-b041-9887f0bc7e4a"
+ONLINE_MEETING_TRANSCRIPT_READ_ALL="30b87d18-ebb1-45db-97f8-82ccb1f0190c"
+CHAT_READ="f501c180-9344-439a-bca0-6cbf209fd270"
+CHANNEL_MESSAGE_READ_ALL="767156cb-16ae-4d10-8f8b-41b657c8c8c8"
+EXTERNAL_ITEM_READ_ALL="922f9392-b1b7-483c-a4be-0089be7704fb"
 
 echo "── Creating app registration: $DISPLAY_NAME ──"
 
@@ -29,10 +36,24 @@ echo "── Adding Graph API delegated permissions ──"
 
 az ad app permission add --id "$APP_ID" --api "$GRAPH_API" \
     --api-permissions \
-        "${USER_READ}=Scope"
+        "${USER_READ}=Scope" \
+        "${SITES_READ_ALL}=Scope" \
+        "${MAIL_READ}=Scope" \
+        "${PEOPLE_READ_ALL}=Scope" \
+        "${ONLINE_MEETING_TRANSCRIPT_READ_ALL}=Scope" \
+        "${CHAT_READ}=Scope" \
+        "${CHANNEL_MESSAGE_READ_ALL}=Scope" \
+        "${EXTERNAL_ITEM_READ_ALL}=Scope"
 
 echo "   Permissions added:"
 echo "     - User.Read"
+echo "     - Sites.Read.All"
+echo "     - Mail.Read"
+echo "     - People.Read.All"
+echo "     - OnlineMeetingTranscript.Read.All"
+echo "     - Chat.Read"
+echo "     - ChannelMessage.Read.All"
+echo "     - ExternalItem.Read.All"
 
 echo "── Creating service principal ──"
 
@@ -49,7 +70,7 @@ az rest --method POST \
         \"clientId\": \"$APP_SP_ID\",
         \"consentType\": \"AllPrincipals\",
         \"resourceId\": \"$GRAPH_SP_ID\",
-        \"scope\": \"User.Read\"
+        \"scope\": \"User.Read Sites.Read.All Mail.Read People.Read.All OnlineMeetingTranscript.Read.All Chat.Read ChannelMessage.Read.All ExternalItem.Read.All\"
     }" -o none
 
 echo ""

--- a/swift/a2a/A2A Chat/Services/AuthService.swift
+++ b/swift/a2a/A2A Chat/Services/AuthService.swift
@@ -171,7 +171,13 @@ class AuthService {
 
     func refreshToken() async -> String? {
         guard application != nil else { return accessToken }
-        _ = try? await acquireTokenSilently()
+        do {
+            _ = try await acquireTokenSilently()
+        } catch {
+            log.error("refreshToken — silent refresh failed: \(error.localizedDescription)")
+            accessToken = nil
+            isAuthenticated = false
+        }
         return accessToken
     }
 

--- a/swift/a2a/setup-app-registration.ps1
+++ b/swift/a2a/setup-app-registration.ps1
@@ -71,6 +71,16 @@ $PlistContent = @"
 <dict>
     <key>ClientId</key>
     <string>$AppId</string>
+    <key>RedirectUri</key>
+    <string>$RedirectUri</string>
+    <key>TenantId</key>
+    <string>common</string>
+    <key>Scopes</key>
+    <array>
+        <string>https://graph.microsoft.com/.default</string>
+    </array>
+    <key>Endpoint</key>
+    <string>YOUR_ENDPOINT_URL</string>
 </dict>
 </plist>
 "@

--- a/swift/a2a/setup-app-registration.sh
+++ b/swift/a2a/setup-app-registration.sh
@@ -85,6 +85,16 @@ cat > "$SCRIPT_DIR/A2A Chat/Configuration.plist" <<PLIST
 <dict>
     <key>ClientId</key>
     <string>$APP_ID</string>
+    <key>RedirectUri</key>
+    <string>$REDIRECT_URI</string>
+    <key>TenantId</key>
+    <string>common</string>
+    <key>Scopes</key>
+    <array>
+        <string>https://graph.microsoft.com/.default</string>
+    </array>
+    <key>Endpoint</key>
+    <string>YOUR_ENDPOINT_URL</string>
 </dict>
 </plist>
 PLIST


### PR DESCRIPTION
## Summary
- **Rust setup scripts**: Add all 7 required Graph delegated permissions (was only `User.Read`), matching the Swift scripts and root README requirements. Update admin consent scope string.
- **Swift `AuthService.refreshToken()`**: Clear `accessToken` and `isAuthenticated` on silent refresh failure instead of returning the stale expired token — callers now get `nil` and can prompt re-auth.
- **Swift setup scripts**: Generate full `Configuration.plist` with `RedirectUri`, `TenantId`, `Scopes`, and `Endpoint` (was only `ClientId`), preventing MSAL redirect URI mismatch errors.
- **.NET `WireLog`**: Re-create `StringContent` after reading request body for logging, so `base.SendAsync()` sends the actual payload instead of an empty body at verbosity 2.

## Test plan
- [ ] Rust: Run `./setup-app-registration.sh` and verify all 8 permissions appear in Azure portal
- [ ] Swift: Run `./setup-app-registration.sh` and verify generated `Configuration.plist` has all keys
- [ ] Swift: Verify that after token expiry, the app returns to the sign-in screen instead of showing opaque errors
- [ ] .NET: Run `dotnet run -- -v 2 --token <jwt>` and verify requests contain the JSON-RPC body

🤖 Generated with [Claude Code](https://claude.com/claude-code)