### PR TITLE
Add --agent-id and --list-agents to a2a samples and remove graph

### DIFF
--- a/ADMIN_SETUP.md
+++ b/ADMIN_SETUP.md
@@ -14,21 +14,18 @@ From the root of this repo:
 
 ```bash
 # Bash / WSL / macOS / Linux
-scripts/admin-setup.sh --workiq
+scripts/admin-setup.sh
 ```
 
 ```powershell
 # Windows PowerShell / PowerShell 7+
-scripts\admin-setup.ps1 -Gateway WorkIQ
+scripts\admin-setup.ps1
 ```
 
 Flags:
 
 | Flag | Meaning |
 |------|---------|
-| `--workiq` (default) | Configure permissions for the Work IQ Gateway (`WorkIQAgent.Ask`). |
-| `--graph` | Configure permissions for Microsoft Graph RP (7 delegated Copilot scopes). |
-| `--both` | Configure both. |
 | `--name "My Name"` / `-Name` | Custom app display name. Default: `Work IQ Samples Client`. |
 | `--tenant <id>` / `-Tenant` | Target tenant (must match your current `az login` context). |
 | `--multi-tenant` / `-MultiTenant` | Configure as multi-tenant (`AzureADMultipleOrgs`). Default is single-tenant. |
@@ -71,30 +68,13 @@ az ad app update --id $APP_ID \
     "https://login.microsoftonline.com/common/oauth2/nativeclient" \
     "ms-appx-web://microsoft.aad.brokerplugin/$APP_ID"
 
-# 5. Add delegated permissions.
-
-# 5a. For Work IQ Gateway samples:
+# 5. Add the delegated permission for the Work IQ Gateway.
 az ad app permission add --id $APP_ID \
   --api fdcc1f02-fc51-4226-8753-f668596af7f7 \
   --api-permissions "0b1715fd-f4bf-4c63-b16d-5be31f9847c2=Scope"
 # Adds: WorkIQAgent.Ask
 
-# 5b. For Microsoft Graph RP samples (add if the developer will also test Graph):
-az ad app permission add --id $APP_ID \
-  --api 00000003-0000-0000-c000-000000000000 \
-  --api-permissions \
-    "205e70e5-aba6-4c52-a976-6d2d46c48043=Scope" \
-    "570282fd-fa5c-430d-a7fd-fc8dc98a9dca=Scope" \
-    "b89f9189-71a5-4e70-b041-9887f0bc7e4a=Scope" \
-    "30b87d18-ebb1-45db-97f8-82ccb1f0190c=Scope" \
-    "f501c180-9344-439a-bca0-6cbf209fd270=Scope" \
-    "767156cb-16ae-4d10-8f8b-41b657c8c8c8=Scope" \
-    "922f9392-b1b7-483c-a4be-0089be7704fb=Scope"
-# Adds: Sites.Read.All, Mail.Read, People.Read.All,
-#       OnlineMeetingTranscript.Read.All, Chat.Read,
-#       ChannelMessage.Read.All, ExternalItem.Read.All
-
-# 6. Grant admin consent for every delegated permission added above.
+# 6. Grant admin consent for the delegated permission added above.
 az ad app permission admin-consent --id $APP_ID
 
 # Print the tenant ID for the developer.
@@ -117,14 +97,11 @@ az account show --query tenantId -o tsv
      - `ms-appx-web://microsoft.aad.brokerplugin/<APP_ID>` (paste the App ID from step 5).
    - Under **Advanced settings** → **Allow public client flows**: **Yes**.
    - **Save**.
-7. **API permissions** → **Add a permission**.
-   - For **Work IQ samples**: *APIs my organization uses* → search **Work IQ** → *Delegated permissions* → check **WorkIQAgent.Ask** → **Add permissions**.
-   - For **Graph RP samples**: *Microsoft Graph* → *Delegated permissions* → add all seven:
-     - `Sites.Read.All`, `Mail.Read`, `People.Read.All`, `OnlineMeetingTranscript.Read.All`, `Chat.Read`, `ChannelMessage.Read.All`, `ExternalItem.Read.All`.
-8. Back on **API permissions**, click **Grant admin consent for [your tenant]**. Confirm. All rows should show ✔️ Granted.
+7. **API permissions** → **Add a permission** → *APIs my organization uses* → search **Work IQ** → *Delegated permissions* → check **WorkIQAgent.Ask** → **Add permissions**.
+8. Back on **API permissions**, click **Grant admin consent for [your tenant]**. Confirm. The row should show ✔️ Granted.
 9. **Microsoft Entra ID** → **Overview** → copy the **Tenant ID**.
 
-Step 8 also JIT-provisions the Work IQ service principal if you picked the Work IQ delegated permission in step 7. If it doesn't (rare), run:
+Step 8 also JIT-provisions the Work IQ service principal. If it doesn't (rare), run:
 
 ```bash
 az ad sp create --id fdcc1f02-fc51-4226-8753-f668596af7f7
@@ -135,8 +112,6 @@ az ad sp create --id fdcc1f02-fc51-4226-8753-f668596af7f7
 ## Work IQ service principal — why that extra step?
 
 Microsoft publishes Work IQ as a multi-tenant app (`fdcc1f02-fc51-4226-8753-f668596af7f7`). For a client app in your tenant to request tokens against Work IQ, a **service principal** for the Work IQ app must exist in your tenant. This is normally created automatically the first time an admin consents to any Work IQ permission, but `az ad sp create --id fdcc1f02-...` forces it explicitly.
-
-Microsoft Graph (`00000003-0000-0000-c000-000000000000`) is in every tenant by default — no SP provisioning needed.
 
 ---
 
@@ -153,7 +128,6 @@ Microsoft Graph (`00000003-0000-0000-c000-000000000000`) is in every tenant by d
 
 1. **App ID** — the GUID from the script's final output (or portal step 5).
 2. **Tenant ID** — the GUID from `az account show --query tenantId -o tsv` (or portal step 9).
-3. **Which gateway(s)** you configured: `--workiq`, `--graph`, or both.
 
 The developer will use these in the sample's `--appid` and `--tenant` flags.
 
@@ -163,10 +137,10 @@ The developer will use these in the sample's `--appid` and `--tenant` flags.
 
 Two folders contain their own setup helpers for language-specific reasons:
 
-- **`rust/a2a/setup-app-registration.sh`** — minimal setup for the Rust device-code sample (no WAM, no redirect URIs).
-- **`swift/a2a/setup-app-registration.sh`** — adds an iOS-specific redirect URI (`msauth.app.blueglass.A2A-Chat://auth`) and generates `Configuration.plist`.
+- **`rust/a2a/setup-app-registration.sh`** — setup for the Rust device-code sample (Graph-targeted; no WAM, no redirect URIs).
+- **`swift/a2a/setup-app-registration.sh`** — Graph-targeted; adds an iOS-specific redirect URI (`msauth.app.blueglass.A2A-Chat://auth`) and generates `Configuration.plist`.
 
-These are narrower; they don't cover the Work IQ Gateway. If you're the admin, the unified `scripts/admin-setup.sh` above covers all three languages for .NET and Rust; for the Swift iOS sample, run the iOS-specific script **after** the unified one (or in addition), because the iOS redirect URI is specific to the app bundle.
+The unified `scripts/admin-setup.sh` above is for the .NET samples (Work IQ Gateway). The Rust and Swift samples target Microsoft Graph and use their own scripts.
 
 ---
 
@@ -179,4 +153,4 @@ These are narrower; they don't cover the Work IQ Gateway. If you're the admin, t
 | `admin-consent` fails with "service principal not found" for Work IQ | Run `az ad sp create --id fdcc1f02-fc51-4226-8753-f668596af7f7` first. |
 | `az ad app permission add` prints a warning about `grant` | Harmless. The next step (`admin-consent`) covers it. |
 | Developer gets `IncorrectConfiguration` on WAM | Redirect URIs were not applied (step 4 / portal step 6). Re-run and confirm all three URIs are present. |
-| Developer gets `403 Required scopes = [...]` | Delegated permissions were added but not admin-consented. Re-run `admin-consent`. |
+| Developer gets `403 Forbidden` without a scope message | User is missing the Microsoft 365 Copilot license. Assign it; wait 15–30 min for propagation. |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Sample clients for the [Work IQ](https://learn.microsoft.com/en-us/microsoft-365
 
 The samples target one of two gateways:
 
-- **Work IQ Gateway** (`workiq.svc.cloud.microsoft`, and dev-ring variants `ppe.workiq.svc.cloud.dev.microsoft` / `test.workiq.svc.cloud.dev.microsoft`) — the dedicated entry point for Work IQ and Copilot Chat. Uses the Work IQ app ID + `WorkIQAgent.Ask` delegated scope.
+- **Work IQ Gateway** (`workiq.svc.cloud.microsoft`) — the dedicated entry point for Work IQ and Copilot Chat. Uses the Work IQ app ID + `WorkIQAgent.Ask` delegated scope.
 - **Microsoft Graph** (`graph.microsoft.com`) — the public Graph surface serving the same Copilot Chat API under `/beta/copilot/*`. Uses the Microsoft Graph app ID + seven delegated Graph scopes.
 
 The .NET samples support both via `--workiq` / `--graph` flags. The Rust and Swift samples target Graph today.
@@ -103,7 +103,7 @@ Note that tokens acquired through `az account get-access-token` carry the Azure 
 | Same error, but redirect URI is present | Single-tenant app + `/common` authority mismatch | Pass `--tenant <TENANT_ID>` so MSAL uses the tenant-specific authority |
 | `403 Forbidden` with `Required scopes = [Sites.Read.All, ...]` | Graph delegated permissions not added + admin-consented on the app | Admin runs `scripts/admin-setup.sh --graph` (or adds the 7 permissions manually + grants admin consent) |
 | `403 Forbidden` without a scope message | User is missing the Microsoft 365 Copilot license | Assign the license; wait 15–30 min for propagation |
-| `400 BadRequest: Invalid request, no valid route` | Using `--endpoint` with an unexpected path on the Work IQ Gateway | Pass host-only to `--endpoint` (e.g. `https://ppe.workiq.svc.cloud.dev.microsoft`); samples append the correct path |
+| `400 BadRequest: Invalid request, no valid route` | Using `--endpoint` with an unexpected path on the Work IQ Gateway | Pass host-only to `--endpoint` (scheme + authority, no path); samples append the correct path |
 | `400 AuthenticationError: Error authenticating with resource` | Gateway rejected the downstream auth exchange (e.g., OBO against an unconfigured downstream service) | Check the request-id in the response headers against the gateway's logs |
 | WAM re-prompts for password on every `dotnet run` | MSAL in-process cache doesn't persist across processes | Expected today. A future update may add an opt-in persistent cache. |
 | `AADSTS65001: consent required` | Admin hasn't consented to the required permissions | Ask admin to run `admin-consent` (step 6 of the setup) |

--- a/README.md
+++ b/README.md
@@ -12,14 +12,11 @@ Sample clients for the [Work IQ](https://learn.microsoft.com/en-us/microsoft-365
 
 ---
 
-## Gateways
+## Gateway
 
-The samples target one of two gateways:
+All .NET samples target the **Work IQ Gateway** (`workiq.svc.cloud.microsoft`) — the dedicated entry point for Work IQ and Copilot Chat. Token audience: `api://workiq.svc.cloud.microsoft`; delegated scope: `WorkIQAgent.Ask`.
 
-- **Work IQ Gateway** (`workiq.svc.cloud.microsoft`) — the dedicated entry point for Work IQ and Copilot Chat. Uses the Work IQ app ID + `WorkIQAgent.Ask` delegated scope.
-- **Microsoft Graph** (`graph.microsoft.com`) — the public Graph surface serving the same Copilot Chat API under `/beta/copilot/*`. Uses the Microsoft Graph app ID + seven delegated Graph scopes.
-
-The .NET samples support both via `--workiq` / `--graph` flags. The Rust and Swift samples target Graph today.
+> The Rust and Swift samples in this repo target Microsoft Graph today and have not been migrated yet.
 
 ---
 
@@ -39,13 +36,13 @@ You (or your tenant admin) must create an Entra app registration with specific p
 - **If you're the admin** — from the repo root:
   ```bash
   # Bash / WSL / macOS / Linux
-  scripts/admin-setup.sh --workiq
+  scripts/admin-setup.sh
   ```
   ```powershell
   # PowerShell
-  scripts\admin-setup.ps1 -Gateway WorkIQ
+  scripts\admin-setup.ps1
   ```
-  Use `--graph` or `--both` to configure Graph permissions as well. See [`ADMIN_SETUP.md`](ADMIN_SETUP.md) for all flags and the manual CLI / portal paths.
+  See [`ADMIN_SETUP.md`](ADMIN_SETUP.md) for all flags and the manual CLI / portal paths.
 
 - **If you're not the admin** — hand [`ADMIN_SETUP.md`](ADMIN_SETUP.md) to them. They'll give you back an **App ID** and **Tenant ID**.
 
@@ -63,7 +60,7 @@ Uses the Windows broker for silent SSO. A browser-less sign-in popup appears on 
 
 ```bash
 cd dotnet/rest
-dotnet run -- --workiq --token WAM --appid <APP_ID> --tenant <TENANT_ID>
+dotnet run -- --token WAM --appid <APP_ID> --tenant <TENANT_ID>
 ```
 
 > **Note:** WAM is only available on Windows. On macOS and Linux, MSAL falls back to an interactive browser sign-in using the `http://localhost` redirect URI — same command works.
@@ -78,16 +75,12 @@ cargo run -- --appid <APP_ID>
 
 ### Pre-obtained JWT token — all platforms, all samples
 
-Acquire a token externally (e.g., via [Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer), `az account get-access-token`, or your own MSAL code) and pass it directly:
+Acquire a token externally (e.g., via `az account get-access-token`, or your own MSAL code) and pass it directly:
 
 ```bash
-# Example: audience = Graph
-TOKEN=$(az account get-access-token --resource https://graph.microsoft.com --query accessToken -o tsv)
-dotnet run -- --graph --token "$TOKEN"
-
-# Example: audience = Work IQ
+# Audience = Work IQ
 TOKEN=$(az account get-access-token --resource api://workiq.svc.cloud.microsoft --query accessToken -o tsv)
-dotnet run -- --workiq --token "$TOKEN"
+dotnet run -- --token "$TOKEN"
 ```
 
 Note that tokens acquired through `az account get-access-token` carry the Azure CLI's client app ID (`04b07795-...`), not your test app. Use this for quick probes, not end-to-end client-identity validation.
@@ -101,13 +94,12 @@ Note that tokens acquired through `az account get-access-token` carry the Azure 
 | `MsalClientException: window_handle_required` | Running `dotnet run` from a context where the console window handle can't be resolved (e.g., piped stdin, some non-interactive shells) | Run from an interactive terminal, or use `--token <jwt>` with a pre-obtained token |
 | `WAM_provider_error 3399614466 / IncorrectConfiguration` | App registration missing the WAM broker redirect URI `ms-appx-web://microsoft.aad.brokerplugin/{appId}` | Ask admin to re-run setup (or add that redirect URI manually). See [`ADMIN_SETUP.md`](ADMIN_SETUP.md). |
 | Same error, but redirect URI is present | Single-tenant app + `/common` authority mismatch | Pass `--tenant <TENANT_ID>` so MSAL uses the tenant-specific authority |
-| `403 Forbidden` with `Required scopes = [Sites.Read.All, ...]` | Graph delegated permissions not added + admin-consented on the app | Admin runs `scripts/admin-setup.sh --graph` (or adds the 7 permissions manually + grants admin consent) |
 | `403 Forbidden` without a scope message | User is missing the Microsoft 365 Copilot license | Assign the license; wait 15–30 min for propagation |
 | `400 BadRequest: Invalid request, no valid route` | Using `--endpoint` with an unexpected path on the Work IQ Gateway | Pass host-only to `--endpoint` (scheme + authority, no path); samples append the correct path |
 | `400 AuthenticationError: Error authenticating with resource` | Gateway rejected the downstream auth exchange (e.g., OBO against an unconfigured downstream service) | Check the request-id in the response headers against the gateway's logs |
 | WAM re-prompts for password on every `dotnet run` | MSAL in-process cache doesn't persist across processes | Expected today. A future update may add an opt-in persistent cache. |
 | `AADSTS65001: consent required` | Admin hasn't consented to the required permissions | Ask admin to run `admin-consent` (step 6 of the setup) |
-| `401 Unauthorized` | Token audience mismatch | Ensure the token `aud` matches the gateway — `https://graph.microsoft.com` for Graph or `fdcc1f02-...`/`api://workiq.svc.cloud.microsoft` for Work IQ |
+| `401 Unauthorized` | Token audience mismatch | Ensure the token `aud` is `fdcc1f02-...` / `api://workiq.svc.cloud.microsoft` |
 | Empty or degraded responses | License just assigned, index not ready | Wait 15–30 minutes after license assignment |
 
 ---
@@ -117,7 +109,6 @@ Note that tokens acquired through `az account get-access-token` carry the Azure 
 - [Work IQ overview](https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/workiq-overview)
 - [Copilot Chat API](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview)
 - [A2A protocol specification](https://a2a-protocol.org/latest/specification/)
-- [Microsoft Graph permissions reference](https://learn.microsoft.com/en-us/graph/permissions-reference)
 - [MSAL.NET documentation](https://learn.microsoft.com/en-us/entra/msal/dotnet/)
 - [`ADMIN_SETUP.md`](ADMIN_SETUP.md) — detailed admin setup guide
 - [`scripts/admin-setup.sh`](scripts/admin-setup.sh) / [`scripts/admin-setup.ps1`](scripts/admin-setup.ps1) — unified app-registration scripts

--- a/dotnet/a2a-raw.tests/ArgParsingTests.cs
+++ b/dotnet/a2a-raw.tests/ArgParsingTests.cs
@@ -121,4 +121,31 @@ public class ArgParsingTests
         Assert.NotNull(r.Error);
         Assert.Contains("Missing value", r.Error);
     }
+
+    [Fact]
+    public void ListAgents_LongFlag_Sets()
+    {
+        var r = Helpers.ParseArgs(["-e", "https://example.com", "-t", "tok", "--list-agents"]);
+        Assert.Null(r.Error);
+        Assert.True(r.ListAgents);
+    }
+
+    [Fact]
+    public void ListAgents_NotProvided_IsFalse()
+    {
+        var r = Helpers.ParseArgs(["-e", "https://example.com", "-t", "tok"]);
+        Assert.Null(r.Error);
+        Assert.False(r.ListAgents);
+    }
+
+    [Fact]
+    public void ListAgents_CombinesWithOtherFlags()
+    {
+        var r = Helpers.ParseArgs(["--endpoint", "https://example.com", "--token", "t", "--appid", "a", "--list-agents"]);
+        Assert.Null(r.Error);
+        Assert.True(r.ListAgents);
+        Assert.Equal("https://example.com", r.Endpoint);
+        Assert.Equal("t", r.Token);
+        Assert.Equal("a", r.AppId);
+    }
 }

--- a/dotnet/a2a-raw.tests/ArgParsingTests.cs
+++ b/dotnet/a2a-raw.tests/ArgParsingTests.cs
@@ -89,4 +89,36 @@ public class ArgParsingTests
         Assert.Null(r.Endpoint);
         Assert.Null(r.Token);
     }
+
+    [Fact]
+    public void AgentId_LongFlag_Captured()
+    {
+        var r = Helpers.ParseArgs(["-e", "https://example.com", "-t", "tok", "--agent-id", "researcher-v2"]);
+        Assert.Null(r.Error);
+        Assert.Equal("researcher-v2", r.AgentId);
+    }
+
+    [Fact]
+    public void AgentId_ShortFlag_Captured()
+    {
+        var r = Helpers.ParseArgs(["-e", "https://example.com", "-t", "tok", "-A", "researcher-v2"]);
+        Assert.Null(r.Error);
+        Assert.Equal("researcher-v2", r.AgentId);
+    }
+
+    [Fact]
+    public void AgentId_NotProvided_IsNull()
+    {
+        var r = Helpers.ParseArgs(["-e", "https://example.com", "-t", "tok"]);
+        Assert.Null(r.Error);
+        Assert.Null(r.AgentId);
+    }
+
+    [Fact]
+    public void AgentId_MissingValue_ReturnsError()
+    {
+        var r = Helpers.ParseArgs(["-e", "https://example.com", "-t", "tok", "--agent-id"]);
+        Assert.NotNull(r.Error);
+        Assert.Contains("Missing value", r.Error);
+    }
 }

--- a/dotnet/a2a-raw/Helpers.cs
+++ b/dotnet/a2a-raw/Helpers.cs
@@ -9,7 +9,7 @@ namespace WorkIQ.A2ARaw;
 public record RawArgs(
     string? Endpoint, string? Token, string? AppId, string? Account,
     string? Scope, string? Tenant, string? AgentId,
-    bool Stream, bool AllHeaders, string? Error);
+    bool Stream, bool AllHeaders, bool ListAgents, string? Error);
 
 public static class Helpers
 {
@@ -18,7 +18,7 @@ public static class Helpers
     public static RawArgs ParseArgs(string[] args)
     {
         string? endpoint = null, token = null, appId = null, account = null, scope = null, tenant = null, agentId = null;
-        bool stream = false, allHeaders = false;
+        bool stream = false, allHeaders = false, listAgents = false;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -47,14 +47,15 @@ public static class Helpers
                     agentId = args[++i]; break;
                 case "--stream": stream = true; break;
                 case "--all-headers": allHeaders = true; break;
+                case "--list-agents": listAgents = true; break;
                 default:
                     return Err($"Unknown flag: {args[i]}");
             }
         }
 
-        return new RawArgs(endpoint, token, appId, account, scope, tenant, agentId, stream, allHeaders, null);
+        return new RawArgs(endpoint, token, appId, account, scope, tenant, agentId, stream, allHeaders, listAgents, null);
 
-        static RawArgs Err(string msg) => new(null, null, null, null, null, null, null, false, false, msg);
+        static RawArgs Err(string msg) => new(null, null, null, null, null, null, null, false, false, false, msg);
     }
 
     // ── A2A response text extraction ────────────────────────────────────

--- a/dotnet/a2a-raw/Helpers.cs
+++ b/dotnet/a2a-raw/Helpers.cs
@@ -8,7 +8,7 @@ namespace WorkIQ.A2ARaw;
 
 public record RawArgs(
     string? Endpoint, string? Token, string? AppId, string? Account,
-    string? Scope, string? Tenant,
+    string? Scope, string? Tenant, string? AgentId,
     bool Stream, bool AllHeaders, string? Error);
 
 public static class Helpers
@@ -17,7 +17,7 @@ public static class Helpers
 
     public static RawArgs ParseArgs(string[] args)
     {
-        string? endpoint = null, token = null, appId = null, account = null, scope = null, tenant = null;
+        string? endpoint = null, token = null, appId = null, account = null, scope = null, tenant = null, agentId = null;
         bool stream = false, allHeaders = false;
 
         for (int i = 0; i < args.Length; i++)
@@ -42,6 +42,9 @@ public static class Helpers
                 case "--tenant" or "-T":
                     if (i + 1 >= args.Length) return Err($"Missing value for {args[i]}");
                     tenant = args[++i]; break;
+                case "--agent-id" or "-A":
+                    if (i + 1 >= args.Length) return Err($"Missing value for {args[i]}");
+                    agentId = args[++i]; break;
                 case "--stream": stream = true; break;
                 case "--all-headers": allHeaders = true; break;
                 default:
@@ -49,9 +52,9 @@ public static class Helpers
             }
         }
 
-        return new RawArgs(endpoint, token, appId, account, scope, tenant, stream, allHeaders, null);
+        return new RawArgs(endpoint, token, appId, account, scope, tenant, agentId, stream, allHeaders, null);
 
-        static RawArgs Err(string msg) => new(null, null, null, null, null, null, false, false, msg);
+        static RawArgs Err(string msg) => new(null, null, null, null, null, null, null, false, false, msg);
     }
 
     // ── A2A response text extraction ────────────────────────────────────

--- a/dotnet/a2a-raw/Program.cs
+++ b/dotnet/a2a-raw/Program.cs
@@ -5,7 +5,7 @@
 // No A2A SDK. Shows exactly what goes over the wire (JSON-RPC v0.3 format).
 //
 // Defaults target the Work IQ Gateway (`https://workiq.svc.cloud.microsoft/a2a/`).
-// Override --endpoint + --scope to target Graph RP or any other A2A endpoint.
+// Override --endpoint + --scope to target any other A2A endpoint.
 //
 // Usage:
 //   dotnet run -- --token <JWT|WAM> --appid <client-id> [--account user@tenant.com] [--stream]
@@ -30,7 +30,7 @@ if (parsed.Error != null)
 }
 
 // Defaults target the Work IQ Gateway (A2A endpoint + matching scope).
-// To target Graph RP instead, override both --endpoint and --scope.
+// Override both --endpoint and --scope to target a different A2A endpoint.
 string endpoint = parsed.Endpoint ?? "https://workiq.svc.cloud.microsoft/a2a/";
 string scope = parsed.Scope ?? "api://workiq.svc.cloud.microsoft/.default";
 string? token = parsed.Token, appId = parsed.AppId, account = parsed.Account, tenant = parsed.Tenant, agentId = parsed.AgentId;
@@ -525,7 +525,7 @@ void PrintUsage()
     Options:
       --endpoint, -e   Agent URL. Defaults to the Work IQ Gateway A2A endpoint:
                        https://workiq.svc.cloud.microsoft/a2a/
-                       Override to target Graph RP or another A2A endpoint.
+                       Override to target a different A2A endpoint.
       --agent-id, -A   Invoke a specific agent. The sample fetches
                        {endpoint}/{agent-id}/.well-known/agent-card.json,
                        reads agentCard.url, and POSTs JSON-RPC there.
@@ -533,7 +533,6 @@ void PrintUsage()
                        --endpoint (default agent for that gateway).
       --scope, -s      Token scope for WAM. Defaults to the Work IQ audience:
                        api://workiq.svc.cloud.microsoft/.default
-                       For Graph RP use: https://graph.microsoft.com/.default
       --appid, -a      App client ID (required with WAM)
       --account        Account hint (e.g., user@contoso.com)
       --tenant, -T     Tenant ID or domain (required with WAM for single-tenant apps;
@@ -549,10 +548,10 @@ void PrintUsage()
       # List agents (discover IDs to use with --agent-id)
       dotnet run -- -t WAM -a <appid> --list-agents
 
-      # Graph RP (override both)
-      dotnet run -- -e https://graph.microsoft.com/rp/workiq/ -s https://graph.microsoft.com/.default -t WAM -a <appid>
+      # Invoke a specific agent
+      dotnet run -- -t WAM -a <appid> --agent-id <AGENT_ID>
 
       # With a pre-obtained JWT
-      dotnet run -- -e https://graph.microsoft.com/rp/workiq/ -t eyJ0eXAi... --stream
+      dotnet run -- -t eyJ0eXAi... --stream
     """);
 }

--- a/dotnet/a2a-raw/Program.cs
+++ b/dotnet/a2a-raw/Program.cs
@@ -487,9 +487,6 @@ void PrintUsage()
       # Work IQ Gateway (uses defaults)
       dotnet run -- -t WAM -a <appid>
 
-      # Work IQ PPE ring (PFT path)
-      dotnet run -- -e https://ppe.workiq.svc.cloud.dev.microsoft/a2a/ -t WAM -a <appid>
-
       # Graph RP (override both)
       dotnet run -- -e https://graph.microsoft.com/rp/workiq/ -s https://graph.microsoft.com/.default -t WAM -a <appid>
 

--- a/dotnet/a2a-raw/Program.cs
+++ b/dotnet/a2a-raw/Program.cs
@@ -33,7 +33,7 @@ if (parsed.Error != null)
 // To target Graph RP instead, override both --endpoint and --scope.
 string endpoint = parsed.Endpoint ?? "https://workiq.svc.cloud.microsoft/a2a/";
 string scope = parsed.Scope ?? "api://workiq.svc.cloud.microsoft/.default";
-string? token = parsed.Token, appId = parsed.AppId, account = parsed.Account, tenant = parsed.Tenant;
+string? token = parsed.Token, appId = parsed.AppId, account = parsed.Account, tenant = parsed.Tenant, agentId = parsed.AgentId;
 bool stream = parsed.Stream, allHeaders = parsed.AllHeaders;
 
 if (string.IsNullOrEmpty(token))
@@ -66,6 +66,59 @@ if (token.Equals("WAM", StringComparison.OrdinalIgnoreCase))
 var http = new HttpClient();
 http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+// ── Agent card resolution (when --agent-id is set) ───────────────────────
+//
+// This sample deliberately does the agent-card fetch in raw HTTP + JSON to
+// show what the wire interaction looks like. With --agent-id the sample:
+//   1. GET {endpoint}/{agentId}/.well-known/agent-card.json
+//   2. Parse the JSON to find:   url, name, capabilities.streaming
+//   3. Replace the POST target with agentCard.url
+//
+// Without --agent-id the sample posts directly to the gateway endpoint
+// (i.e., the default agent for that gateway).
+if (!string.IsNullOrEmpty(agentId))
+{
+    var cardUri = $"{endpoint.TrimEnd('/')}/{agentId}/.well-known/agent-card.json";
+    try
+    {
+        var cardRes = await http.GetAsync(cardUri);
+        if (!cardRes.IsSuccessStatusCode)
+        {
+            Console.Error.WriteLine($"ERROR: failed to fetch agent card: {(int)cardRes.StatusCode} {cardRes.StatusCode} from {cardUri}");
+            return;
+        }
+
+        var cardJson = await cardRes.Content.ReadAsStringAsync();
+        using var cardDoc = JsonDocument.Parse(cardJson);
+        var root = cardDoc.RootElement;
+
+        var resolvedUrl = root.GetProperty("url").GetString()
+            ?? throw new InvalidOperationException("agent-card.json has no 'url' field");
+        var resolvedName = root.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "";
+        var streamingSupported = root.TryGetProperty("capabilities", out var caps)
+            && caps.TryGetProperty("streaming", out var s) && s.GetBoolean();
+
+        Console.WriteLine($"Agent card:");
+        Console.WriteLine($"  id              {agentId}");
+        Console.WriteLine($"  name            {resolvedName}");
+        Console.WriteLine($"  url             {resolvedUrl}");
+        Console.WriteLine($"  streaming       {streamingSupported}");
+
+        if (stream && !streamingSupported)
+        {
+            Console.WriteLine("  note: agent does not advertise streaming; falling back to sync");
+            stream = false;
+        }
+
+        endpoint = resolvedUrl;
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"ERROR: failed to resolve agent '{agentId}': {ex.Message}");
+        return;
+    }
+}
 
 string? contextId = null;
 
@@ -415,6 +468,11 @@ void PrintUsage()
       --endpoint, -e   Agent URL. Defaults to the Work IQ Gateway A2A endpoint:
                        https://workiq.svc.cloud.microsoft/a2a/
                        Override to target other rings (e.g., ppe./test.) or Graph RP.
+      --agent-id, -A   Invoke a specific agent. The sample fetches
+                       {endpoint}/{agent-id}/.well-known/agent-card.json,
+                       reads agentCard.url, and POSTs JSON-RPC there.
+                       Without --agent-id, the sample posts directly to
+                       --endpoint (default agent for that gateway).
       --scope, -s      Token scope for WAM. Defaults to the Work IQ audience:
                        api://workiq.svc.cloud.microsoft/.default
                        For Graph RP use: https://graph.microsoft.com/.default

--- a/dotnet/a2a-raw/Program.cs
+++ b/dotnet/a2a-raw/Program.cs
@@ -34,7 +34,7 @@ if (parsed.Error != null)
 string endpoint = parsed.Endpoint ?? "https://workiq.svc.cloud.microsoft/a2a/";
 string scope = parsed.Scope ?? "api://workiq.svc.cloud.microsoft/.default";
 string? token = parsed.Token, appId = parsed.AppId, account = parsed.Account, tenant = parsed.Tenant, agentId = parsed.AgentId;
-bool stream = parsed.Stream, allHeaders = parsed.AllHeaders;
+bool stream = parsed.Stream, allHeaders = parsed.AllHeaders, listAgents = parsed.ListAgents;
 
 if (string.IsNullOrEmpty(token))
 {
@@ -66,6 +66,64 @@ if (token.Equals("WAM", StringComparison.OrdinalIgnoreCase))
 var http = new HttpClient();
 http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+
+// ── --list-agents: GET {endpoint}/.agents and exit ───────────────────────
+//
+// {endpoint}/.agents is a Work IQ / Sydney extension (not part of the A2A
+// spec) returning an array of {agentId, name, provider} entries. Useful for
+// discovering IDs to pass to --agent-id.
+if (listAgents)
+{
+    var listUri = $"{endpoint.TrimEnd('/')}/.agents";
+    HttpResponseMessage listRes;
+    try { listRes = await http.GetAsync(listUri); }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"ERROR: failed to GET {listUri}: {ex.Message}");
+        return;
+    }
+
+    if (!listRes.IsSuccessStatusCode)
+    {
+        var body = await listRes.Content.ReadAsStringAsync();
+        Console.Error.WriteLine($"ERROR: {(int)listRes.StatusCode} {listRes.ReasonPhrase} from {listUri}");
+        if (!string.IsNullOrWhiteSpace(body)) Console.Error.WriteLine($"  {body.Trim()}");
+        return;
+    }
+
+    var listJson = await listRes.Content.ReadAsStringAsync();
+    using var listDoc = JsonDocument.Parse(listJson);
+    if (listDoc.RootElement.ValueKind != JsonValueKind.Array)
+    {
+        Console.Error.WriteLine($"ERROR: expected JSON array from {listUri}, got {listDoc.RootElement.ValueKind}");
+        return;
+    }
+
+    var rows = listDoc.RootElement.EnumerateArray()
+        .Select(e => (
+            Id: e.TryGetProperty("agentId", out var id) ? id.GetString() ?? "" : "",
+            Name: e.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "",
+            Provider: e.TryGetProperty("provider", out var p) ? p.GetString() ?? "" : ""))
+        .ToList();
+
+    Console.WriteLine();
+    Console.WriteLine($"Agents at {endpoint}:");
+    Console.WriteLine();
+    if (rows.Count == 0)
+    {
+        Console.WriteLine("  (none)");
+        return;
+    }
+
+    int wId = Math.Max(8, rows.Max(r => r.Id.Length));
+    int wName = Math.Max(4, rows.Max(r => r.Name.Length));
+    Console.WriteLine($"  {"AGENT ID".PadRight(wId)}  {"NAME".PadRight(wName)}  PROVIDER");
+    foreach (var r in rows)
+        Console.WriteLine($"  {r.Id.PadRight(wId)}  {r.Name.PadRight(wName)}  {r.Provider}");
+    Console.WriteLine();
+    Console.WriteLine($"{rows.Count} agent{(rows.Count == 1 ? "" : "s")}.");
+    return;
+}
 
 // ── Agent card resolution (when --agent-id is set) ───────────────────────
 //
@@ -467,7 +525,7 @@ void PrintUsage()
     Options:
       --endpoint, -e   Agent URL. Defaults to the Work IQ Gateway A2A endpoint:
                        https://workiq.svc.cloud.microsoft/a2a/
-                       Override to target other rings (e.g., ppe./test.) or Graph RP.
+                       Override to target Graph RP or another A2A endpoint.
       --agent-id, -A   Invoke a specific agent. The sample fetches
                        {endpoint}/{agent-id}/.well-known/agent-card.json,
                        reads agentCard.url, and POSTs JSON-RPC there.
@@ -482,10 +540,14 @@ void PrintUsage()
                        defaults to 'common' for multi-tenant apps)
       --stream         Use streaming mode (SSE via message/stream)
       --all-headers    Print all response headers (default: key diagnostics only)
+      --list-agents    GET {endpoint}/.agents and print, then exit (no chat loop)
 
     Examples:
       # Work IQ Gateway (uses defaults)
       dotnet run -- -t WAM -a <appid>
+
+      # List agents (discover IDs to use with --agent-id)
+      dotnet run -- -t WAM -a <appid> --list-agents
 
       # Graph RP (override both)
       dotnet run -- -e https://graph.microsoft.com/rp/workiq/ -s https://graph.microsoft.com/.default -t WAM -a <appid>

--- a/dotnet/a2a-raw/README.md
+++ b/dotnet/a2a-raw/README.md
@@ -43,15 +43,6 @@ dotnet run -- --token WAM --appid <APP_ID> --tenant <TENANT_ID>
 
 Type a message, see a response, type `quit` to exit.
 
-### Against the Work IQ Gateway, a specific ring (e.g., `ppe.`)
-
-```bash
-dotnet run -- --endpoint https://ppe.workiq.svc.cloud.dev.microsoft/a2a/ \
-  --token WAM --appid <APP_ID> --tenant <TENANT_ID>
-```
-
-The raw sample takes the **full URL** in `--endpoint` (including the `/a2a/` path) — unlike the SDK sample, there are no gateway presets.
-
 ### Against Microsoft Graph
 
 ```bash

--- a/dotnet/a2a-raw/README.md
+++ b/dotnet/a2a-raw/README.md
@@ -66,6 +66,60 @@ For Graph, override **both** `--endpoint` (path is different) and `--scope` (aud
 
 Add `--stream` to switch from `message/send` to `message/stream`.
 
+### Invoking a specific agent (`--agent-id`)
+
+Without `--agent-id`, the sample POSTs directly to `--endpoint` (the gateway's default agent). To target a specific agent:
+
+```bash
+dotnet run -- --agent-id <AGENT_ID> --token WAM --appid <APP_ID> --tenant <TENANT_ID>
+```
+
+The sample then does **two raw HTTP calls** — illustrating exactly what a non-.NET / no-SDK port would do:
+
+1. **Agent card fetch**:
+   ```
+   GET {endpoint}/{agent-id}/.well-known/agent-card.json
+   Authorization: Bearer <token>
+   ```
+   Response is the standard A2A agent card JSON. The sample parses three fields:
+   - `url` — where to POST messages for this agent
+   - `name` — friendly name (for logging)
+   - `capabilities.streaming` — whether `message/stream` is supported
+
+2. **Message post** — same JSON-RPC shape as before, but POSTed to `agentCard.url` (read from step 1) instead of `--endpoint`.
+
+If `--stream` is set but the agent's card has `capabilities.streaming = false`, the sample falls back to `message/send` automatically and prints a note.
+
+#### Agent card wire format (what the GET returns)
+
+```json
+{
+  "name": "Researcher Agent",
+  "description": "...",
+  "url": "https://substrate.office.com/m365Copilot/agents/<agent-id>/",
+  "version": "1.0",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": false
+  },
+  "defaultInputModes": ["text/plain"],
+  "defaultOutputModes": ["text/plain"],
+  "skills": [...]
+}
+```
+
+This is the [A2A AgentCard schema](https://a2a-protocol.org/latest/specification/#agent-card). Useful as a porting reference if you're implementing this in another language.
+
+#### How to find an agent ID
+
+Agent IDs are stable identifiers exposed by the gateway's agent registry (`{endpoint}/.agents`). For now, get them from product documentation or by querying the registry directly:
+
+```bash
+curl -H "Authorization: Bearer <token>" {endpoint}/.agents
+```
+
+A list-agents sample is on the roadmap.
+
 ### With a pre-obtained JWT (any platform)
 
 ```bash
@@ -103,6 +157,7 @@ You > quit
 | `--appid, -a` | Entra app client ID (required with `WAM`) |
 | `--tenant, -T` | Tenant ID or domain. Required with `WAM` for single-tenant apps; defaults to `common` for multi-tenant. |
 | `--account` | Account hint for WAM (e.g., `user@contoso.com`) |
+| `--agent-id, -A` | Invoke a specific agent (fetches `.well-known/agent-card.json` and POSTs to `agentCard.url`) |
 | `--stream` | Use streaming mode (`message/stream` via SSE) |
 | `--all-headers` | Print every response header (default: only diagnostic ones) |
 

--- a/dotnet/a2a-raw/README.md
+++ b/dotnet/a2a-raw/README.md
@@ -101,15 +101,31 @@ If `--stream` is set but the agent's card has `capabilities.streaming = false`, 
 
 This is the [A2A AgentCard schema](https://a2a-protocol.org/latest/specification/#agent-card). Useful as a porting reference if you're implementing this in another language.
 
-#### How to find an agent ID
+#### How to find an agent ID — `--list-agents`
 
-Agent IDs are stable identifiers exposed by the gateway's agent registry (`{endpoint}/.agents`). For now, get them from product documentation or by querying the registry directly:
+Agent IDs are stable identifiers exposed by the gateway's agent registry (`{endpoint}/.agents`, a Work IQ / Sydney extension — not part of the A2A spec). Pass `--list-agents` to fetch and print the registry, then exit:
+
+```bash
+dotnet run -- --token WAM --appid <APP_ID> --tenant <TENANT_ID> --list-agents
+```
+
+The sample does a single `GET {endpoint}/.agents` with the bearer token and prints the `{agentId, name, provider}` rows. Sample output:
+
+```
+Agents at https://workiq.svc.cloud.microsoft/a2a/:
+
+  AGENT ID                  NAME              PROVIDER
+  bizchat-as-gpt-scenario   BizChat           Microsoft
+  researcher-v1             Researcher        Microsoft
+
+5 agents.
+```
+
+Equivalent raw curl:
 
 ```bash
 curl -H "Authorization: Bearer <token>" {endpoint}/.agents
 ```
-
-A list-agents sample is on the roadmap.
 
 ### With a pre-obtained JWT (any platform)
 
@@ -149,6 +165,7 @@ You > quit
 | `--tenant, -T` | Tenant ID or domain. Required with `WAM` for single-tenant apps; defaults to `common` for multi-tenant. |
 | `--account` | Account hint for WAM (e.g., `user@contoso.com`) |
 | `--agent-id, -A` | Invoke a specific agent (fetches `.well-known/agent-card.json` and POSTs to `agentCard.url`) |
+| `--list-agents` | GET `{endpoint}/.agents` and print, then exit (no chat loop). Use to discover agent IDs. |
 | `--stream` | Use streaming mode (`message/stream` via SSE) |
 | `--all-headers` | Print every response header (default: only diagnostic ones) |
 

--- a/dotnet/a2a-raw/README.md
+++ b/dotnet/a2a-raw/README.md
@@ -4,7 +4,7 @@ A bare-minimum A2A client using only `HttpClient` and `System.Text.Json` — **n
 
 This sample **calls the agent endpoint directly** — no agent card retrieval, no discovery, no capability negotiation. It assumes you already know the agent URL and sends JSON-RPC v0.3 messages to it.
 
-Defaults target the **Work IQ Gateway** (`https://workiq.svc.cloud.microsoft/a2a/`). Use `--endpoint` + `--scope` to target Microsoft Graph or any other A2A endpoint.
+Defaults target the **Work IQ Gateway** (`https://workiq.svc.cloud.microsoft/a2a/`). Use `--endpoint` + `--scope` to target a different A2A endpoint.
 
 > **Protocol version**: This sample uses the **A2A v0.3 JSON-RPC wire format**, which is what the Work IQ server currently supports. The A2A spec has since moved to v1.0 with a REST-style API (different URL paths, no JSON-RPC envelope). This sample will be updated to v1.0 when the server is upgraded.
 
@@ -26,9 +26,9 @@ Use this sample when you want to understand the A2A protocol at the HTTP level, 
    - If you're the tenant admin:
      ```bash
      # Bash
-     ../../scripts/admin-setup.sh --workiq    # or --graph or --both
+     ../../scripts/admin-setup.sh
      # PowerShell
-     ..\..\scripts\admin-setup.ps1 -Gateway WorkIQ
+     ..\..\scripts\admin-setup.ps1
      ```
    - Otherwise, hand [`../../ADMIN_SETUP.md`](../../ADMIN_SETUP.md) to your admin. They'll give you an **App ID** and **Tenant ID**.
 3. **.NET 10 SDK** or later — [download](https://dotnet.microsoft.com/download/dotnet/10.0).
@@ -42,16 +42,6 @@ dotnet run -- --token WAM --appid <APP_ID> --tenant <TENANT_ID>
 ```
 
 Type a message, see a response, type `quit` to exit.
-
-### Against Microsoft Graph
-
-```bash
-dotnet run -- --endpoint https://graph.microsoft.com/rp/workiq/ \
-  --scope https://graph.microsoft.com/.default \
-  --token WAM --appid <APP_ID> --tenant <TENANT_ID>
-```
-
-For Graph, override **both** `--endpoint` (path is different) and `--scope` (audience is Graph, not Work IQ).
 
 ### Streaming mode
 
@@ -130,7 +120,7 @@ curl -H "Authorization: Bearer <token>" {endpoint}/.agents
 ### With a pre-obtained JWT (any platform)
 
 ```bash
-dotnet run -- --endpoint https://graph.microsoft.com/rp/workiq/ --token eyJ0eXAi...
+dotnet run -- --token eyJ0eXAi...
 ```
 
 > **macOS / Linux users:** WAM is only available on Windows. Use `--token <JWT>` with a pre-obtained token instead.
@@ -160,7 +150,7 @@ You > quit
 |------|-------------|
 | `--token, -t` | `WAM` for Windows broker auth, or a pre-obtained JWT string. **Required.** |
 | `--endpoint, -e` | Full agent URL. Default: `https://workiq.svc.cloud.microsoft/a2a/` |
-| `--scope, -s` | Token scope for WAM. Default: `api://workiq.svc.cloud.microsoft/.default`. For Graph use `https://graph.microsoft.com/.default`. |
+| `--scope, -s` | Token scope for WAM. Default: `api://workiq.svc.cloud.microsoft/.default` |
 | `--appid, -a` | Entra app client ID (required with `WAM`) |
 | `--tenant, -T` | Tenant ID or domain. Required with `WAM` for single-tenant apps; defaults to `common` for multi-tenant. |
 | `--account` | Account hint for WAM (e.g., `user@contoso.com`) |
@@ -220,14 +210,14 @@ Text accumulates across events (not incremental deltas). The sample diffs agains
 | `Microsoft.Identity.Client` | MSAL token acquisition |
 | `Microsoft.Identity.Client.Broker` | Windows WAM broker |
 
-That's it — no A2A SDK, no JWT decoder, no Graph SDK.
+That's it — no A2A SDK, no JWT decoder.
 
 ## Sample-specific troubleshooting
 
 | Symptom | Fix |
 |---------|-----|
-| `400 Invalid request, no valid route` | Your `--endpoint` path doesn't match a gateway-registered scope. Use `/a2a/` for Work IQ, `/rp/workiq/` for Graph. |
-| `401 Unauthorized` | Token `aud` doesn't match the endpoint. Work IQ needs `api://workiq.svc.cloud.microsoft/.default`; Graph needs `https://graph.microsoft.com/.default`. |
+| `400 Invalid request, no valid route` | Your `--endpoint` path doesn't match a gateway-registered scope. Use `/a2a/` for the Work IQ Gateway. |
+| `401 Unauthorized` | Token `aud` doesn't match the endpoint. The Work IQ Gateway needs `api://workiq.svc.cloud.microsoft/.default`. |
 | `403 Forbidden` without a scope message | User is missing the Microsoft 365 Copilot license. |
 
 See the [root README](../../README.md#troubleshooting) for the full troubleshooting matrix.

--- a/dotnet/a2a.tests/ArgParsingTests.cs
+++ b/dotnet/a2a.tests/ArgParsingTests.cs
@@ -105,4 +105,36 @@ public class ArgParsingTests
         Assert.Null(r.Error);
         Assert.Equal(1, r.Verbosity);
     }
+
+    [Fact]
+    public void AgentId_LongFlag_Captured()
+    {
+        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--agent-id", "researcher-v2"]);
+        Assert.Null(r.Error);
+        Assert.Equal("researcher-v2", r.AgentId);
+    }
+
+    [Fact]
+    public void AgentId_ShortFlag_Captured()
+    {
+        var r = Helpers.ParseArgs(["--graph", "--token", "t", "-A", "researcher-v2"]);
+        Assert.Null(r.Error);
+        Assert.Equal("researcher-v2", r.AgentId);
+    }
+
+    [Fact]
+    public void AgentId_NotProvided_IsNull()
+    {
+        var r = Helpers.ParseArgs(["--graph", "--token", "t"]);
+        Assert.Null(r.Error);
+        Assert.Null(r.AgentId);
+    }
+
+    [Fact]
+    public void AgentId_MissingValue_ReturnsError()
+    {
+        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--agent-id"]);
+        Assert.NotNull(r.Error);
+        Assert.Contains("Missing value", r.Error);
+    }
 }

--- a/dotnet/a2a.tests/ArgParsingTests.cs
+++ b/dotnet/a2a.tests/ArgParsingTests.cs
@@ -15,45 +15,25 @@ public class ArgParsingTests
     [Fact]
     public void ValidArgs_ProduceCorrectConfig()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "mytoken", "--appid", "app1", "--stream"]);
+        var r = Helpers.ParseArgs(["--token", "mytoken", "--appid", "app1", "--stream"]);
         Assert.Null(r.Error);
         Assert.Equal("mytoken", r.Token);
         Assert.Equal("app1", r.AppId);
         Assert.True(r.Stream);
-        Assert.True(r.Graph);
     }
 
     [Fact]
     public void MissingToken_ReturnsNullToken()
     {
-        var r = Helpers.ParseArgs(["--graph"]);
+        var r = Helpers.ParseArgs([]);
         Assert.Null(r.Error);
         Assert.Null(r.Token);
     }
 
     [Fact]
-    public void MissingGateway_NoGatewayFlagSet()
-    {
-        var r = Helpers.ParseArgs(["--token", "abc"]);
-        Assert.Null(r.Error);
-        Assert.False(r.Graph);
-        Assert.False(r.Workiq);
-    }
-
-    [Fact]
-    public void GraphAndWorkiqTogether_BothFlagsSet()
-    {
-        // Mutual-exclusion is enforced at the Program.cs layer, not here.
-        var r = Helpers.ParseArgs(["--graph", "--workiq", "--token", "abc"]);
-        Assert.Null(r.Error);
-        Assert.True(r.Graph);
-        Assert.True(r.Workiq);
-    }
-
-    [Fact]
     public void EndpointOverride_Captured()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--endpoint", "https://custom.com/"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--endpoint", "https://custom.com/"]);
         Assert.Null(r.Error);
         Assert.Equal("https://custom.com/", r.Endpoint);
     }
@@ -61,7 +41,7 @@ public class ArgParsingTests
     [Fact]
     public void HeaderValues_AreCollected()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--header", "X-Custom: v1", "-H", "X-Other: v2"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--header", "X-Custom: v1", "-H", "X-Other: v2"]);
         Assert.Null(r.Error);
         Assert.Equal(2, r.Headers.Count);
     }
@@ -69,7 +49,7 @@ public class ArgParsingTests
     [Fact]
     public void VerbosityWithNonInteger_ReturnsError()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--verbosity", "abc"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--verbosity", "abc"]);
         Assert.NotNull(r.Error);
         Assert.Contains("integer", r.Error);
     }
@@ -77,7 +57,7 @@ public class ArgParsingTests
     [Fact]
     public void VerbosityWithInteger_Parsed()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--verbosity", "3"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--verbosity", "3"]);
         Assert.Null(r.Error);
         Assert.Equal(3, r.Verbosity);
     }
@@ -85,7 +65,7 @@ public class ArgParsingTests
     [Fact]
     public void MissingValueAfterToken_ReturnsError()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token"]);
+        var r = Helpers.ParseArgs(["--token"]);
         Assert.NotNull(r.Error);
         Assert.Contains("Missing value", r.Error);
     }
@@ -93,7 +73,7 @@ public class ArgParsingTests
     [Fact]
     public void MissingValueAfterEndpoint_ReturnsError()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--endpoint"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--endpoint"]);
         Assert.NotNull(r.Error);
         Assert.Contains("Missing value", r.Error);
     }
@@ -101,7 +81,7 @@ public class ArgParsingTests
     [Fact]
     public void DefaultVerbosity_IsOne()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t"]);
+        var r = Helpers.ParseArgs(["--token", "t"]);
         Assert.Null(r.Error);
         Assert.Equal(1, r.Verbosity);
     }
@@ -109,7 +89,7 @@ public class ArgParsingTests
     [Fact]
     public void AgentId_LongFlag_Captured()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--agent-id", "researcher-v2"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--agent-id", "researcher-v2"]);
         Assert.Null(r.Error);
         Assert.Equal("researcher-v2", r.AgentId);
     }
@@ -117,7 +97,7 @@ public class ArgParsingTests
     [Fact]
     public void AgentId_ShortFlag_Captured()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "-A", "researcher-v2"]);
+        var r = Helpers.ParseArgs(["--token", "t", "-A", "researcher-v2"]);
         Assert.Null(r.Error);
         Assert.Equal("researcher-v2", r.AgentId);
     }
@@ -125,7 +105,7 @@ public class ArgParsingTests
     [Fact]
     public void AgentId_NotProvided_IsNull()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t"]);
+        var r = Helpers.ParseArgs(["--token", "t"]);
         Assert.Null(r.Error);
         Assert.Null(r.AgentId);
     }
@@ -133,7 +113,7 @@ public class ArgParsingTests
     [Fact]
     public void AgentId_MissingValue_ReturnsError()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--agent-id"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--agent-id"]);
         Assert.NotNull(r.Error);
         Assert.Contains("Missing value", r.Error);
     }
@@ -141,7 +121,7 @@ public class ArgParsingTests
     [Fact]
     public void ListAgents_LongFlag_Sets()
     {
-        var r = Helpers.ParseArgs(["--workiq", "--token", "t", "--list-agents"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--list-agents"]);
         Assert.Null(r.Error);
         Assert.True(r.ListAgents);
     }
@@ -149,7 +129,7 @@ public class ArgParsingTests
     [Fact]
     public void ListAgents_NotProvided_IsFalse()
     {
-        var r = Helpers.ParseArgs(["--workiq", "--token", "t"]);
+        var r = Helpers.ParseArgs(["--token", "t"]);
         Assert.Null(r.Error);
         Assert.False(r.ListAgents);
     }
@@ -157,10 +137,9 @@ public class ArgParsingTests
     [Fact]
     public void ListAgents_CombinesWithOtherFlags()
     {
-        var r = Helpers.ParseArgs(["--workiq", "--token", "t", "--appid", "x", "--list-agents", "--tenant", "common"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--appid", "x", "--list-agents", "--tenant", "common"]);
         Assert.Null(r.Error);
         Assert.True(r.ListAgents);
-        Assert.True(r.Workiq);
         Assert.Equal("t", r.Token);
         Assert.Equal("x", r.AppId);
         Assert.Equal("common", r.Tenant);

--- a/dotnet/a2a.tests/ArgParsingTests.cs
+++ b/dotnet/a2a.tests/ArgParsingTests.cs
@@ -137,4 +137,32 @@ public class ArgParsingTests
         Assert.NotNull(r.Error);
         Assert.Contains("Missing value", r.Error);
     }
+
+    [Fact]
+    public void ListAgents_LongFlag_Sets()
+    {
+        var r = Helpers.ParseArgs(["--workiq", "--token", "t", "--list-agents"]);
+        Assert.Null(r.Error);
+        Assert.True(r.ListAgents);
+    }
+
+    [Fact]
+    public void ListAgents_NotProvided_IsFalse()
+    {
+        var r = Helpers.ParseArgs(["--workiq", "--token", "t"]);
+        Assert.Null(r.Error);
+        Assert.False(r.ListAgents);
+    }
+
+    [Fact]
+    public void ListAgents_CombinesWithOtherFlags()
+    {
+        var r = Helpers.ParseArgs(["--workiq", "--token", "t", "--appid", "x", "--list-agents", "--tenant", "common"]);
+        Assert.Null(r.Error);
+        Assert.True(r.ListAgents);
+        Assert.True(r.Workiq);
+        Assert.Equal("t", r.Token);
+        Assert.Equal("x", r.AppId);
+        Assert.Equal("common", r.Tenant);
+    }
 }

--- a/dotnet/a2a/Helpers.cs
+++ b/dotnet/a2a/Helpers.cs
@@ -9,7 +9,7 @@ namespace WorkIQ.A2A;
 public record A2AArgs(
     string? Token, string? AppId, string? Endpoint, string? Account, string? Tenant,
     string? AgentId,
-    bool Graph, bool Workiq, bool ShowToken, bool Stream, bool ListAgents,
+    bool ShowToken, bool Stream, bool ListAgents,
     int Verbosity, List<string> Headers, string? Error);
 
 public static class Helpers
@@ -19,7 +19,7 @@ public static class Helpers
     public static A2AArgs ParseArgs(string[] args)
     {
         string? token = null, appId = null, endpoint = null, account = null, tenant = null, agentId = null;
-        bool graph = false, workiq = false, showToken = false, stream = false, listAgents = false;
+        bool showToken = false, stream = false, listAgents = false;
         int verbosity = 1;
         var headers = new List<string>();
 
@@ -27,8 +27,6 @@ public static class Helpers
         {
             switch (args[i])
             {
-                case "--graph": graph = true; break;
-                case "--workiq": workiq = true; break;
                 case "--token" or "-t":
                     if (i + 1 >= args.Length) return Err($"Missing value for {args[i]}");
                     token = args[++i]; break;
@@ -61,9 +59,9 @@ public static class Helpers
             }
         }
 
-        return new A2AArgs(token, appId, endpoint, account, tenant, agentId, graph, workiq, showToken, stream, listAgents, verbosity, headers, null);
+        return new A2AArgs(token, appId, endpoint, account, tenant, agentId, showToken, stream, listAgents, verbosity, headers, null);
 
-        static A2AArgs Err(string msg) => new(null, null, null, null, null, null, false, false, false, false, false, 1, new List<string>(), msg);
+        static A2AArgs Err(string msg) => new(null, null, null, null, null, null, false, false, false, 1, new List<string>(), msg);
     }
 
     // ── Response extraction (uses A2A SDK types) ────────────────────────

--- a/dotnet/a2a/Helpers.cs
+++ b/dotnet/a2a/Helpers.cs
@@ -8,6 +8,7 @@ namespace WorkIQ.A2A;
 
 public record A2AArgs(
     string? Token, string? AppId, string? Endpoint, string? Account, string? Tenant,
+    string? AgentId,
     bool Graph, bool Workiq, bool ShowToken, bool Stream,
     int Verbosity, List<string> Headers, string? Error);
 
@@ -17,7 +18,7 @@ public static class Helpers
 
     public static A2AArgs ParseArgs(string[] args)
     {
-        string? token = null, appId = null, endpoint = null, account = null, tenant = null;
+        string? token = null, appId = null, endpoint = null, account = null, tenant = null, agentId = null;
         bool graph = false, workiq = false, showToken = false, stream = false;
         int verbosity = 1;
         var headers = new List<string>();
@@ -43,6 +44,9 @@ public static class Helpers
                 case "--tenant" or "-T":
                     if (i + 1 >= args.Length) return Err($"Missing value for {args[i]}");
                     tenant = args[++i]; break;
+                case "--agent-id" or "-A":
+                    if (i + 1 >= args.Length) return Err($"Missing value for {args[i]}");
+                    agentId = args[++i]; break;
                 case "--show-token": showToken = true; break;
                 case "--stream": stream = true; break;
                 case "--verbosity" or "-v":
@@ -56,9 +60,9 @@ public static class Helpers
             }
         }
 
-        return new A2AArgs(token, appId, endpoint, account, tenant, graph, workiq, showToken, stream, verbosity, headers, null);
+        return new A2AArgs(token, appId, endpoint, account, tenant, agentId, graph, workiq, showToken, stream, verbosity, headers, null);
 
-        static A2AArgs Err(string msg) => new(null, null, null, null, null, false, false, false, false, 1, new List<string>(), msg);
+        static A2AArgs Err(string msg) => new(null, null, null, null, null, null, false, false, false, false, 1, new List<string>(), msg);
     }
 
     // ── Response extraction (uses A2A SDK types) ────────────────────────

--- a/dotnet/a2a/Helpers.cs
+++ b/dotnet/a2a/Helpers.cs
@@ -9,7 +9,7 @@ namespace WorkIQ.A2A;
 public record A2AArgs(
     string? Token, string? AppId, string? Endpoint, string? Account, string? Tenant,
     string? AgentId,
-    bool Graph, bool Workiq, bool ShowToken, bool Stream,
+    bool Graph, bool Workiq, bool ShowToken, bool Stream, bool ListAgents,
     int Verbosity, List<string> Headers, string? Error);
 
 public static class Helpers
@@ -19,7 +19,7 @@ public static class Helpers
     public static A2AArgs ParseArgs(string[] args)
     {
         string? token = null, appId = null, endpoint = null, account = null, tenant = null, agentId = null;
-        bool graph = false, workiq = false, showToken = false, stream = false;
+        bool graph = false, workiq = false, showToken = false, stream = false, listAgents = false;
         int verbosity = 1;
         var headers = new List<string>();
 
@@ -49,6 +49,7 @@ public static class Helpers
                     agentId = args[++i]; break;
                 case "--show-token": showToken = true; break;
                 case "--stream": stream = true; break;
+                case "--list-agents": listAgents = true; break;
                 case "--verbosity" or "-v":
                     if (i + 1 >= args.Length) return Err($"Missing value for {args[i]}");
                     if (!int.TryParse(args[++i], out verbosity))
@@ -60,9 +61,9 @@ public static class Helpers
             }
         }
 
-        return new A2AArgs(token, appId, endpoint, account, tenant, agentId, graph, workiq, showToken, stream, verbosity, headers, null);
+        return new A2AArgs(token, appId, endpoint, account, tenant, agentId, graph, workiq, showToken, stream, listAgents, verbosity, headers, null);
 
-        static A2AArgs Err(string msg) => new(null, null, null, null, null, null, false, false, false, false, 1, new List<string>(), msg);
+        static A2AArgs Err(string msg) => new(null, null, null, null, null, null, false, false, false, false, false, 1, new List<string>(), msg);
     }
 
     // ── Response extraction (uses A2A SDK types) ────────────────────────

--- a/dotnet/a2a/Program.cs
+++ b/dotnet/a2a/Program.cs
@@ -38,12 +38,49 @@ if (config.Verbosity >= 1)
 
 WireLog.Verbosity = config.Verbosity;
 var httpClient = CreateHttpClient(token, config.Gateway);
-var a2a = new A2AClient(new Uri(config.Gateway.Endpoint), httpClient);
+
+// Resolve the A2A target URL.
+//   --agent-id not set: post directly to the gateway endpoint (default agent for that gateway).
+//   --agent-id set:     fetch the agent card from {gateway}/{agentId}/.well-known/agent-card.json
+//                       (handled by A2ACardResolver) and use agentCard.Url as the A2A endpoint.
+string a2aEndpoint = config.Gateway.Endpoint;
+bool effectiveStream = config.Stream;
+if (!string.IsNullOrEmpty(config.AgentId))
+{
+    var gateway = config.Gateway.Endpoint.TrimEnd('/');
+    var agentRoot = new Uri($"{gateway}/{config.AgentId}/");
+    var resolver = new A2ACardResolver(agentRoot, httpClient);
+    AgentCard agentCard;
+    try { agentCard = await resolver.GetAgentCardAsync(); }
+    catch (Exception ex)
+    {
+        Ink($"ERROR: failed to fetch agent card for '{config.AgentId}' at {agentRoot}: {ex.Message}\n", ConsoleColor.Red);
+        return;
+    }
+
+    a2aEndpoint = agentCard.Url;
+    if (config.Stream && !agentCard.Capabilities.Streaming)
+    {
+        if (config.Verbosity >= 1) Ink($"  note: agent '{agentCard.Name}' does not advertise streaming; falling back to sync\n", ConsoleColor.DarkYellow);
+        effectiveStream = false;
+    }
+
+    if (config.Verbosity >= 1)
+    {
+        Log("AGENT");
+        Console.WriteLine($"  id              {config.AgentId}");
+        Console.WriteLine($"  name            {agentCard.Name}");
+        Console.WriteLine($"  url             {agentCard.Url}");
+        Console.WriteLine($"  streaming       {agentCard.Capabilities.Streaming}");
+    }
+}
+
+var a2a = new A2AClient(new Uri(a2aEndpoint), httpClient);
 string? contextId = null;
 
 if (config.Verbosity >= 1)
 {
-    Log($"READY — {config.Gateway.Name} — {(config.Stream ? "Streaming" : "Sync")} — {config.Gateway.Endpoint}");
+    Log($"READY — {config.Gateway.Name} — {(effectiveStream ? "Streaming" : "Sync")} — {a2aEndpoint}");
     Console.WriteLine("Type a message. 'quit' to exit.\n");
 }
 
@@ -85,7 +122,7 @@ while (true)
         var sw = Stopwatch.StartNew();
         Dictionary<string, JsonElement>? responseMetadata = null;
 
-        if (config.Stream)
+        if (effectiveStream)
         {
             var previousText = string.Empty;
             await foreach (var sseItem in a2a.SendMessageStreamingAsync(new MessageSendParams { Message = msg }))
@@ -267,7 +304,7 @@ static Config? ParseArgs(string[] args)
         return null;
     }
 
-    string? token = a.Token, appId = a.AppId, endpoint = a.Endpoint, account = a.Account, tenant = a.Tenant;
+    string? token = a.Token, appId = a.AppId, endpoint = a.Endpoint, account = a.Account, tenant = a.Tenant, agentId = a.AgentId;
     bool graph = a.Graph, workiq = a.Workiq, showToken = a.ShowToken, stream = a.Stream;
     int verbosity = a.Verbosity;
     var headers = a.Headers;
@@ -294,6 +331,11 @@ static Config? ParseArgs(string[] args)
               --endpoint, -e   Override the gateway host (scheme + authority only, no path).
                                The gateway-specific path (/rp/workiq/ for Graph, /a2a/ for
                                Work IQ) is preserved automatically.
+              --agent-id, -A   Invoke a specific agent. The sample fetches the agent card
+                               from {gateway}/{agent-id}/.well-known/agent-card.json and
+                               uses agentCard.url as the A2A endpoint. Without --agent-id,
+                               the sample posts to the gateway endpoint directly (default
+                               agent for that gateway).
               --header, -H     Custom HTTP header in 'Key: Value' format (repeatable)
               --show-token     Print the raw JWT token (for reuse with --token)
               --stream         Use streaming mode (SSE via message/stream)
@@ -305,6 +347,7 @@ static Config? ParseArgs(string[] args)
               dotnet run -- --graph --token eyJ0eXAi...
               dotnet run -- --workiq --token WAM --appid <your-app-id>
               dotnet run -- --workiq --endpoint https://test.workiq.svc.cloud.dev.microsoft --token WAM --appid <your-app-id>
+              dotnet run -- --workiq --agent-id <AGENT_ID> --token WAM --appid <your-app-id>
             """);
         return null;
     }
@@ -335,7 +378,7 @@ static Config? ParseArgs(string[] args)
         gw = gw with { ExtraHeaders = [.. gw.ExtraHeaders, .. headers] };
     }
 
-    return new Config(token, appId ?? "", gw, account, tenant, showToken, verbosity, stream);
+    return new Config(token, appId ?? "", gw, account, tenant, agentId, showToken, verbosity, stream);
 }
 
 // ── Citations ─────────────────────────────────────────────────────────────
@@ -394,7 +437,7 @@ static void Ink(string s, ConsoleColor c) { Console.ForegroundColor = c; Console
 [DllImport("user32.dll", ExactSpelling = true)] static extern IntPtr GetAncestor(IntPtr hwnd, uint flags);
 static IntPtr ConsoleWindowHandle() { var c = Win32GetConsoleWindow(); var r = GetAncestor(c, 3); return r != IntPtr.Zero ? r : c; }
 
-record Config(string Token, string AppId, GatewayConfig Gateway, string? Account, string? Tenant, bool ShowToken, int Verbosity, bool Stream);
+record Config(string Token, string AppId, GatewayConfig Gateway, string? Account, string? Tenant, string? AgentId, bool ShowToken, int Verbosity, bool Stream);
 
 // ── Gateway definitions ──────────────────────────────────────────────────
 

--- a/dotnet/a2a/Program.cs
+++ b/dotnet/a2a/Program.cs
@@ -1,6 +1,5 @@
-// WorkIQ A2A Sample — Interactive A2A session via Graph RP or WorkIQ Gateway
-// Usage: dotnet run -- --graph --token <JWT|WAM> --appid <clientId> [options]
-//        dotnet run -- --workiq --token <JWT|WAM> --appid <clientId> [options]
+// WorkIQ A2A Sample — Interactive A2A session via the Work IQ Gateway
+// Usage: dotnet run -- --token <JWT|WAM> --appid <clientId> [options]
 
 using System.Diagnostics;
 using System.IdentityModel.Tokens.Jwt;
@@ -366,20 +365,16 @@ static Config? ParseArgs(string[] args)
     }
 
     string? token = a.Token, appId = a.AppId, endpoint = a.Endpoint, account = a.Account, tenant = a.Tenant, agentId = a.AgentId;
-    bool graph = a.Graph, workiq = a.Workiq, showToken = a.ShowToken, stream = a.Stream, listAgents = a.ListAgents;
+    bool showToken = a.ShowToken, stream = a.Stream, listAgents = a.ListAgents;
     int verbosity = a.Verbosity;
     var headers = a.Headers;
 
-    if (string.IsNullOrEmpty(token) || (!graph && !workiq))
+    if (string.IsNullOrEmpty(token))
     {
         Console.WriteLine("""
-            WorkIQ A2A Sample — Interactive A2A agent session
+            WorkIQ A2A Sample — Interactive A2A agent session against the Work IQ Gateway
 
-            Usage: dotnet run -- <gateway> --token <JWT|WAM> --appid <clientId> [options]
-
-            Gateway (exactly one required):
-              --graph          Use Microsoft Graph RP gateway
-              --workiq         Use Work IQ Gateway
+            Usage: dotnet run -- --token <JWT|WAM> --appid <clientId> [options]
 
             Auth:
               --token, -t      Bearer token or 'WAM' for Windows broker auth
@@ -390,13 +385,12 @@ static Config? ParseArgs(string[] args)
 
             Options:
               --endpoint, -e   Override the gateway host (scheme + authority only, no path).
-                               The gateway-specific path (/rp/workiq/ for Graph, /a2a/ for
-                               Work IQ) is preserved automatically.
+                               The /a2a/ path is preserved automatically.
               --agent-id, -A   Invoke a specific agent. The sample fetches the agent card
                                from {gateway}/{agent-id}/.well-known/agent-card.json and
                                uses agentCard.url as the A2A endpoint. Without --agent-id,
-                               the sample posts to the gateway endpoint directly (default
-                               agent for that gateway).
+                               the sample posts to the gateway endpoint directly (the
+                               default BizChat agent).
               --header, -H     Custom HTTP header in 'Key: Value' format (repeatable)
               --show-token     Print the raw JWT token (for reuse with --token)
               --stream         Use streaming mode (SSE via message/stream)
@@ -404,19 +398,12 @@ static Config? ParseArgs(string[] args)
               -v, --verbosity  0 = response only, 1 = default, 2 = full wire
 
             Examples:
-              dotnet run -- --graph --token WAM --appid <your-app-id>
-              dotnet run -- --graph --token WAM --appid <your-app-id> --account user@contoso.com
-              dotnet run -- --graph --token eyJ0eXAi...
-              dotnet run -- --workiq --token WAM --appid <your-app-id>
-              dotnet run -- --workiq --agent-id <AGENT_ID> --token WAM --appid <your-app-id>
-              dotnet run -- --workiq --list-agents --token WAM --appid <your-app-id>
+              dotnet run -- --token WAM --appid <your-app-id> --tenant <your-tenant>
+              dotnet run -- --token WAM --appid <your-app-id> --account user@contoso.com
+              dotnet run -- --token WAM --appid <your-app-id> --agent-id <AGENT_ID>
+              dotnet run -- --token WAM --appid <your-app-id> --list-agents
+              dotnet run -- --token eyJ0eXAi...
             """);
-        return null;
-    }
-
-    if (graph && workiq)
-    {
-        Ink("ERROR: specify --graph or --workiq, not both\n", ConsoleColor.Red);
         return null;
     }
 
@@ -426,10 +413,10 @@ static Config? ParseArgs(string[] args)
         return null;
     }
 
-    var gw = graph ? Gateways.Graph : Gateways.WorkIQ;
+    var gw = Gateways.WorkIQ;
     if (!string.IsNullOrEmpty(endpoint))
     {
-        // --endpoint is host-only (scheme + authority). Preserve the gateway's path.
+        // --endpoint is host-only (scheme + authority). Preserve the /a2a/ path.
         var hostUri = new Uri(endpoint.TrimEnd('/'));
         var presetPath = new Uri(gw.Endpoint).AbsolutePath;
         gw = gw with { Endpoint = $"{hostUri.Scheme}://{hostUri.Authority}{presetPath}" };
@@ -507,13 +494,6 @@ record GatewayConfig(string Name, string Endpoint, string[] Scopes, string Autho
 
 class Gateways
 {
-    public static readonly GatewayConfig Graph = new(
-        Name: "Graph RP",
-        Endpoint: "https://graph.microsoft.com/rp/workiq/",
-        Scopes: ["https://graph.microsoft.com/.default"],
-        Authority: "https://login.microsoftonline.com/common",
-        ExtraHeaders: []);
-
     public static readonly GatewayConfig WorkIQ = new(
         Name: "Work IQ Gateway",
         Endpoint: "https://workiq.svc.cloud.microsoft/a2a/",

--- a/dotnet/a2a/Program.cs
+++ b/dotnet/a2a/Program.cs
@@ -39,6 +39,15 @@ if (config.Verbosity >= 1)
 WireLog.Verbosity = config.Verbosity;
 var httpClient = CreateHttpClient(token, config.Gateway);
 
+// --list-agents: GET {endpoint}/.agents and print, then exit. The endpoint
+// is a Work IQ / Sydney extension (not part of the A2A spec) returning an
+// array of {agentId, name, provider} entries.
+if (config.ListAgents)
+{
+    await ListAgentsAsync(config.Gateway.Endpoint, httpClient);
+    return;
+}
+
 // Resolve the A2A target URL.
 //   --agent-id not set: post directly to the gateway endpoint (default agent for that gateway).
 //   --agent-id set:     fetch the agent card from {gateway}/{agentId}/.well-known/agent-card.json
@@ -217,6 +226,58 @@ static HttpClient CreateHttpClient(string bearerToken, GatewayConfig gw)
     return client;
 }
 
+static async Task ListAgentsAsync(string endpoint, HttpClient httpClient)
+{
+    var url = new Uri($"{endpoint.TrimEnd('/')}/.agents");
+    HttpResponseMessage response;
+    try { response = await httpClient.GetAsync(url); }
+    catch (Exception ex)
+    {
+        Ink($"ERROR: failed to GET {url}: {ex.Message}\n", ConsoleColor.Red);
+        return;
+    }
+
+    if (!response.IsSuccessStatusCode)
+    {
+        var body = await response.Content.ReadAsStringAsync();
+        Ink($"ERROR: {(int)response.StatusCode} {response.ReasonPhrase} from {url}\n", ConsoleColor.Red);
+        if (!string.IsNullOrWhiteSpace(body)) Console.Error.WriteLine($"  {body.Trim()}");
+        return;
+    }
+
+    var json = await response.Content.ReadAsStringAsync();
+    using var doc = JsonDocument.Parse(json);
+    if (doc.RootElement.ValueKind != JsonValueKind.Array)
+    {
+        Ink($"ERROR: expected JSON array from {url}, got {doc.RootElement.ValueKind}\n", ConsoleColor.Red);
+        return;
+    }
+
+    var agents = doc.RootElement.EnumerateArray()
+        .Select(e => (
+            Id: e.TryGetProperty("agentId", out var id) ? id.GetString() ?? "" : "",
+            Name: e.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "",
+            Provider: e.TryGetProperty("provider", out var p) ? p.GetString() ?? "" : ""))
+        .ToList();
+
+    Console.WriteLine();
+    Console.WriteLine($"Agents at {endpoint}:");
+    Console.WriteLine();
+    if (agents.Count == 0)
+    {
+        Console.WriteLine("  (none)");
+        return;
+    }
+
+    int wId = Math.Max(8, agents.Max(a => a.Id.Length));
+    int wName = Math.Max(4, agents.Max(a => a.Name.Length));
+    Ink($"  {"AGENT ID".PadRight(wId)}  {"NAME".PadRight(wName)}  PROVIDER\n", ConsoleColor.DarkGray);
+    foreach (var a in agents)
+        Console.WriteLine($"  {a.Id.PadRight(wId)}  {a.Name.PadRight(wName)}  {a.Provider}");
+    Console.WriteLine();
+    Console.WriteLine($"{agents.Count} agent{(agents.Count == 1 ? "" : "s")}.");
+}
+
 // ── WAM auth ─────────────────────────────────────────────────────────────
 
 static async Task<(string token, IPublicClientApplication app, IAccount? account)> AcquireWamToken(
@@ -305,7 +366,7 @@ static Config? ParseArgs(string[] args)
     }
 
     string? token = a.Token, appId = a.AppId, endpoint = a.Endpoint, account = a.Account, tenant = a.Tenant, agentId = a.AgentId;
-    bool graph = a.Graph, workiq = a.Workiq, showToken = a.ShowToken, stream = a.Stream;
+    bool graph = a.Graph, workiq = a.Workiq, showToken = a.ShowToken, stream = a.Stream, listAgents = a.ListAgents;
     int verbosity = a.Verbosity;
     var headers = a.Headers;
 
@@ -339,6 +400,7 @@ static Config? ParseArgs(string[] args)
               --header, -H     Custom HTTP header in 'Key: Value' format (repeatable)
               --show-token     Print the raw JWT token (for reuse with --token)
               --stream         Use streaming mode (SSE via message/stream)
+              --list-agents    GET {endpoint}/.agents and print, then exit (no chat loop)
               -v, --verbosity  0 = response only, 1 = default, 2 = full wire
 
             Examples:
@@ -347,6 +409,7 @@ static Config? ParseArgs(string[] args)
               dotnet run -- --graph --token eyJ0eXAi...
               dotnet run -- --workiq --token WAM --appid <your-app-id>
               dotnet run -- --workiq --agent-id <AGENT_ID> --token WAM --appid <your-app-id>
+              dotnet run -- --workiq --list-agents --token WAM --appid <your-app-id>
             """);
         return null;
     }
@@ -377,7 +440,7 @@ static Config? ParseArgs(string[] args)
         gw = gw with { ExtraHeaders = [.. gw.ExtraHeaders, .. headers] };
     }
 
-    return new Config(token, appId ?? "", gw, account, tenant, agentId, showToken, verbosity, stream);
+    return new Config(token, appId ?? "", gw, account, tenant, agentId, showToken, verbosity, stream, listAgents);
 }
 
 // ── Citations ─────────────────────────────────────────────────────────────
@@ -436,7 +499,7 @@ static void Ink(string s, ConsoleColor c) { Console.ForegroundColor = c; Console
 [DllImport("user32.dll", ExactSpelling = true)] static extern IntPtr GetAncestor(IntPtr hwnd, uint flags);
 static IntPtr ConsoleWindowHandle() { var c = Win32GetConsoleWindow(); var r = GetAncestor(c, 3); return r != IntPtr.Zero ? r : c; }
 
-record Config(string Token, string AppId, GatewayConfig Gateway, string? Account, string? Tenant, string? AgentId, bool ShowToken, int Verbosity, bool Stream);
+record Config(string Token, string AppId, GatewayConfig Gateway, string? Account, string? Tenant, string? AgentId, bool ShowToken, int Verbosity, bool Stream, bool ListAgents);
 
 // ── Gateway definitions ──────────────────────────────────────────────────
 

--- a/dotnet/a2a/Program.cs
+++ b/dotnet/a2a/Program.cs
@@ -346,7 +346,6 @@ static Config? ParseArgs(string[] args)
               dotnet run -- --graph --token WAM --appid <your-app-id> --account user@contoso.com
               dotnet run -- --graph --token eyJ0eXAi...
               dotnet run -- --workiq --token WAM --appid <your-app-id>
-              dotnet run -- --workiq --endpoint https://test.workiq.svc.cloud.dev.microsoft --token WAM --appid <your-app-id>
               dotnet run -- --workiq --agent-id <AGENT_ID> --token WAM --appid <your-app-id>
             """);
         return null;

--- a/dotnet/a2a/README.md
+++ b/dotnet/a2a/README.md
@@ -70,9 +70,27 @@ dotnet run -- --graph --agent-id <AGENT_ID> --token WAM \
   --appid <APP_ID> --tenant <TENANT_ID>
 ```
 
-#### How to find an agent ID
+#### How to find an agent ID — `--list-agents`
 
-Agent IDs are stable identifiers exposed by the gateway's agent registry. **For now**, you'll get them from product documentation or by listing the registry yourself (a future sample / tool will surface this; out of scope today). A list-agents sample is on the roadmap.
+Pass `--list-agents` to fetch and print the gateway's agent registry. The sample GETs `{endpoint}/.agents` (a Work IQ / Sydney extension, not part of the A2A spec) and prints `{agentId, name, provider}` for each entry, then exits — no chat loop:
+
+```bash
+dotnet run -- --workiq --list-agents --token WAM \
+  --appid <APP_ID> --tenant <TENANT_ID>
+```
+
+Sample output:
+
+```
+Agents at https://workiq.svc.cloud.microsoft/a2a/:
+
+  AGENT ID                  NAME              PROVIDER
+  bizchat-as-gpt-scenario   BizChat           Microsoft
+  researcher-v1             Researcher        Microsoft
+  ...
+
+5 agents.
+```
 
 The Work IQ default agent (BizChat-as-GPT scenario) has id `bizchat-as-gpt-scenario` — but you don't need `--agent-id` to invoke it; not specifying any agent already routes there.
 
@@ -120,6 +138,7 @@ If the `── TOKEN ──` block shows an `aud` that matches the gateway and `
 | `--account` | Account hint for WAM (e.g., `user@contoso.com`) |
 | `--endpoint, -e` | Override the gateway host (scheme + authority only, no path) |
 | `--agent-id, -A` | Invoke a specific agent (fetches `{gateway}/{agent-id}/.well-known/agent-card.json` and posts to `agentCard.url`) |
+| `--list-agents` | GET `{endpoint}/.agents` and print, then exit (no chat loop). Use to discover agent IDs. |
 | `--stream` | Use streaming mode (`message/stream` via SSE) |
 | `--header, -H` | Custom request header (repeatable) |
 | `--show-token` | Print the raw JWT after decoding |

--- a/dotnet/a2a/README.md
+++ b/dotnet/a2a/README.md
@@ -2,7 +2,7 @@
 
 A minimal, single-file interactive client for communicating with Work IQ agents using the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org).
 
-Uses the [A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) (NuGet: [`A2A`](https://www.nuget.org/packages/A2A/)) for JSON-RPC transport. Supports both synchronous (`message/send`) and streaming (`message/stream`) modes, against either the **Work IQ Gateway** or **Microsoft Graph**.
+Uses the [A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) (NuGet: [`A2A`](https://www.nuget.org/packages/A2A/)) for JSON-RPC transport. Supports both synchronous (`message/send`) and streaming (`message/stream`) modes against the **Work IQ Gateway**.
 
 For the lower-level sample with no SDK (raw HTTP + JSON), see [`../a2a-raw/`](../a2a-raw/).
 
@@ -20,28 +20,22 @@ The **Agent-to-Agent (A2A) Protocol** is an open standard for communication betw
    - If you're the tenant admin:
      ```bash
      # Bash
-     ../../scripts/admin-setup.sh --workiq    # or --graph or --both
+     ../../scripts/admin-setup.sh
      # PowerShell
-     ..\..\scripts\admin-setup.ps1 -Gateway WorkIQ
+     ..\..\scripts\admin-setup.ps1
      ```
    - Otherwise, hand [`../../ADMIN_SETUP.md`](../../ADMIN_SETUP.md) to your admin. They'll give you an **App ID** and **Tenant ID**.
 3. **.NET 10 SDK** or later — [download](https://dotnet.microsoft.com/download/dotnet/10.0).
 
 ## Quick start
 
-### Against the Work IQ Gateway (default host `workiq.svc.cloud.microsoft`)
+### Default — talk to the Work IQ Gateway's BizChat agent
 
 ```bash
-dotnet run -- --workiq --token WAM --appid <APP_ID> --tenant <TENANT_ID>
+dotnet run -- --token WAM --appid <APP_ID> --tenant <TENANT_ID>
 ```
 
 Type a message, see a response, type `quit` to exit.
-
-### Against Microsoft Graph
-
-```bash
-dotnet run -- --graph --token WAM --appid <APP_ID> --tenant <TENANT_ID>
-```
 
 ### Streaming mode
 
@@ -49,10 +43,10 @@ Add `--stream` to switch from `message/send` (sync) to `message/stream` (SSE).
 
 ### Invoking a specific agent (`--agent-id`)
 
-Without `--agent-id`, the sample posts directly to the gateway endpoint (default agent for that gateway). To invoke a specific agent, pass `--agent-id <id>`:
+Without `--agent-id`, the sample posts directly to the gateway endpoint (the default BizChat agent). To invoke a specific agent, pass `--agent-id <id>`:
 
 ```bash
-dotnet run -- --workiq --agent-id <AGENT_ID> --token WAM \
+dotnet run -- --token WAM --agent-id <AGENT_ID> \
   --appid <APP_ID> --tenant <TENANT_ID>
 ```
 
@@ -63,19 +57,12 @@ The sample then:
 3. Uses `agentCard.url` (not the gateway endpoint) as the target for `A2AClient`.
 4. Falls back to sync mode if `--stream` is set but the agent doesn't advertise streaming (a note prints at `-v >= 1`).
 
-Same pattern works for `--graph`:
-
-```bash
-dotnet run -- --graph --agent-id <AGENT_ID> --token WAM \
-  --appid <APP_ID> --tenant <TENANT_ID>
-```
-
 #### How to find an agent ID — `--list-agents`
 
 Pass `--list-agents` to fetch and print the gateway's agent registry. The sample GETs `{endpoint}/.agents` (a Work IQ / Sydney extension, not part of the A2A spec) and prints `{agentId, name, provider}` for each entry, then exits — no chat loop:
 
 ```bash
-dotnet run -- --workiq --list-agents --token WAM \
+dotnet run -- --token WAM --list-agents \
   --appid <APP_ID> --tenant <TENANT_ID>
 ```
 
@@ -97,7 +84,7 @@ The Work IQ default agent (BizChat-as-GPT scenario) has id `bizchat-as-gpt-scena
 ### With a pre-obtained JWT (any platform)
 
 ```bash
-dotnet run -- --graph --token eyJ0eXAi...
+dotnet run -- --token eyJ0eXAi...
 ```
 
 > **macOS / Linux users:** WAM is only available on Windows. Use `--token <JWT>` with a pre-obtained token instead.
@@ -125,13 +112,12 @@ Agent > You've exchanged 8 emails with Alice this week. Key threads:
 You > quit
 ```
 
-If the `── TOKEN ──` block shows an `aud` that matches the gateway and `scp` includes `WorkIQAgent.Ask` (or the 7 Graph scopes), auth is working.
+If the `── TOKEN ──` block shows `aud` matching the Work IQ Gateway and `scp` includes `WorkIQAgent.Ask`, auth is working.
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--graph` / `--workiq` | Gateway selection. Exactly one required. |
 | `--token, -t` | `WAM` for Windows broker auth, or a pre-obtained JWT string |
 | `--appid, -a` | Entra app client ID (required with `WAM`) |
 | `--tenant, -T` | Tenant ID or domain. Required with `WAM` for single-tenant apps; defaults to `common` for multi-tenant. |
@@ -148,10 +134,10 @@ If the `── TOKEN ──` block shows an `aud` that matches the gateway and `
 
 ```
 ┌──────────────┐   JSON-RPC POST    ┌──────────────────┐
-│  This Sample │ ────────────────>  │  Gateway / Agent │
-│  (A2A Client)│ <────────────────  │  (Work IQ or     │
-└──────────────┘   AgentMessage     │   Graph RP)      │
-                  or AgentTask      └──────────────────┘
+│  This Sample │ ────────────────>  │  Work IQ Gateway │
+│  (A2A Client)│ <────────────────  │  / Agent         │
+└──────────────┘   AgentMessage     └──────────────────┘
+                  or AgentTask
 ```
 
 1. **Auth**: acquires a token via WAM or accepts a pre-obtained JWT.
@@ -220,7 +206,7 @@ if (agentMessage.Metadata?.TryGetValue("attributions", out var attrs) == true
 Use `-v 2` to see full HTTP request/response details:
 
 ```
-  > POST https://graph.microsoft.com/rp/workiq/
+  > POST https://workiq.svc.cloud.microsoft/a2a/
     Authorization: Bearer ...(3089c)
     Content-Type: application/json
     Body: {"jsonrpc":"2.0","method":"message/send","params":{...}}

--- a/dotnet/a2a/README.md
+++ b/dotnet/a2a/README.md
@@ -56,6 +56,35 @@ dotnet run -- --graph --token WAM --appid <APP_ID> --tenant <TENANT_ID>
 
 Add `--stream` to switch from `message/send` (sync) to `message/stream` (SSE).
 
+### Invoking a specific agent (`--agent-id`)
+
+Without `--agent-id`, the sample posts directly to the gateway endpoint (default agent for that gateway). To invoke a specific agent, pass `--agent-id <id>`:
+
+```bash
+dotnet run -- --workiq --agent-id <AGENT_ID> --token WAM \
+  --appid <APP_ID> --tenant <TENANT_ID>
+```
+
+The sample then:
+
+1. Fetches the agent card from `{gateway}/{agent-id}/.well-known/agent-card.json` via the A2A SDK's `A2ACardResolver`.
+2. Reads `agentCard.url`, `agentCard.name`, `agentCard.capabilities.streaming` from the response.
+3. Uses `agentCard.url` (not the gateway endpoint) as the target for `A2AClient`.
+4. Falls back to sync mode if `--stream` is set but the agent doesn't advertise streaming (a note prints at `-v >= 1`).
+
+Same pattern works for `--graph`:
+
+```bash
+dotnet run -- --graph --agent-id <AGENT_ID> --token WAM \
+  --appid <APP_ID> --tenant <TENANT_ID>
+```
+
+#### How to find an agent ID
+
+Agent IDs are stable identifiers exposed by the gateway's agent registry. **For now**, you'll get them from product documentation or by listing the registry yourself (a future sample / tool will surface this; out of scope today). A list-agents sample is on the roadmap.
+
+The Work IQ default agent (BizChat-as-GPT scenario) has id `bizchat-as-gpt-scenario` — but you don't need `--agent-id` to invoke it; not specifying any agent already routes there.
+
 ### With a pre-obtained JWT (any platform)
 
 ```bash
@@ -99,6 +128,7 @@ If the `── TOKEN ──` block shows an `aud` that matches the gateway and `
 | `--tenant, -T` | Tenant ID or domain. Required with `WAM` for single-tenant apps; defaults to `common` for multi-tenant. |
 | `--account` | Account hint for WAM (e.g., `user@contoso.com`) |
 | `--endpoint, -e` | Override the gateway host (scheme + authority only, no path) |
+| `--agent-id, -A` | Invoke a specific agent (fetches `{gateway}/{agent-id}/.well-known/agent-card.json` and posts to `agentCard.url`) |
 | `--stream` | Use streaming mode (`message/stream` via SSE) |
 | `--header, -H` | Custom request header (repeatable) |
 | `--show-token` | Print the raw JWT after decoding |

--- a/dotnet/a2a/README.md
+++ b/dotnet/a2a/README.md
@@ -37,15 +37,6 @@ dotnet run -- --workiq --token WAM --appid <APP_ID> --tenant <TENANT_ID>
 
 Type a message, see a response, type `quit` to exit.
 
-### Against the Work IQ Gateway, a specific ring (e.g., `ppe.`)
-
-```bash
-dotnet run -- --workiq --endpoint https://ppe.workiq.svc.cloud.dev.microsoft \
-  --token WAM --appid <APP_ID> --tenant <TENANT_ID>
-```
-
-`--endpoint` takes **host-only** (scheme + authority). The sample preserves the gateway's path (`/a2a/`).
-
 ### Against Microsoft Graph
 
 ```bash

--- a/dotnet/rest.tests/ArgParsingTests.cs
+++ b/dotnet/rest.tests/ArgParsingTests.cs
@@ -15,47 +15,26 @@ public class ArgParsingTests
     [Fact]
     public void ValidArgs_ProduceCorrectConfig()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "mytoken", "--appid", "app1", "--stream", "--account", "user@test.com"]);
+        var r = Helpers.ParseArgs(["--token", "mytoken", "--appid", "app1", "--stream", "--account", "user@test.com"]);
         Assert.Null(r.Error);
         Assert.Equal("mytoken", r.Token);
         Assert.Equal("app1", r.AppId);
         Assert.Equal("user@test.com", r.Account);
         Assert.True(r.Stream);
-        Assert.True(r.Graph);
-    }
-
-    [Fact]
-    public void GraphAndWorkiqTogether_BothFlagsSet()
-    {
-        // The Helpers.ParseArgs layer just extracts flags — mutual-exclusion is
-        // enforced at the Program.cs Config-construction layer.
-        var r = Helpers.ParseArgs(["--graph", "--workiq", "--token", "abc"]);
-        Assert.Null(r.Error);
-        Assert.True(r.Graph);
-        Assert.True(r.Workiq);
     }
 
     [Fact]
     public void MissingToken_ReturnsNullToken()
     {
-        var r = Helpers.ParseArgs(["--graph"]);
+        var r = Helpers.ParseArgs([]);
         Assert.Null(r.Error);
         Assert.Null(r.Token);
     }
 
     [Fact]
-    public void MissingGateway_NoGatewayFlagSet()
-    {
-        var r = Helpers.ParseArgs(["--token", "abc"]);
-        Assert.Null(r.Error);
-        Assert.False(r.Graph);
-        Assert.False(r.Workiq);
-    }
-
-    [Fact]
     public void VerbosityWithNonInteger_ReturnsError()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--verbosity", "abc"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--verbosity", "abc"]);
         Assert.NotNull(r.Error);
         Assert.Contains("integer", r.Error);
     }
@@ -63,7 +42,7 @@ public class ArgParsingTests
     [Fact]
     public void VerbosityWithInteger_Parsed()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--verbosity", "2"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--verbosity", "2"]);
         Assert.Null(r.Error);
         Assert.Equal(2, r.Verbosity);
     }
@@ -71,7 +50,7 @@ public class ArgParsingTests
     [Fact]
     public void HeaderValues_AreCollected()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--header", "X-Custom: value1", "-H", "X-Other: value2"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--header", "X-Custom: value1", "-H", "X-Other: value2"]);
         Assert.Null(r.Error);
         Assert.Equal(2, r.Headers.Count);
         Assert.Equal("X-Custom: value1", r.Headers[0]);
@@ -81,7 +60,7 @@ public class ArgParsingTests
     [Fact]
     public void ShowToken_Parsed()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--show-token"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--show-token"]);
         Assert.Null(r.Error);
         Assert.True(r.ShowToken);
     }
@@ -89,7 +68,7 @@ public class ArgParsingTests
     [Fact]
     public void DefaultVerbosity_IsOne()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t"]);
+        var r = Helpers.ParseArgs(["--token", "t"]);
         Assert.Null(r.Error);
         Assert.Equal(1, r.Verbosity);
     }
@@ -97,7 +76,7 @@ public class ArgParsingTests
     [Fact]
     public void MissingValueAfterToken_ReturnsError()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token"]);
+        var r = Helpers.ParseArgs(["--token"]);
         Assert.NotNull(r.Error);
         Assert.Contains("Missing value", r.Error);
     }
@@ -105,7 +84,7 @@ public class ArgParsingTests
     [Fact]
     public void MissingValueAfterHeader_ReturnsError()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--header"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--header"]);
         Assert.NotNull(r.Error);
         Assert.Contains("Missing value", r.Error);
     }
@@ -113,24 +92,24 @@ public class ArgParsingTests
     [Fact]
     public void MissingValueAfterVerbosity_ReturnsError()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--verbosity"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--verbosity"]);
         Assert.NotNull(r.Error);
         Assert.Contains("Missing value", r.Error);
     }
 
     [Fact]
-    public void WorkiqGateway_FlagRecognized()
+    public void StreamFlag_SetsStreamTrue()
     {
-        var r = Helpers.ParseArgs(["--workiq", "--token", "X"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--stream"]);
         Assert.Null(r.Error);
-        Assert.True(r.Workiq);
+        Assert.True(r.Stream);
     }
 
     [Fact]
-    public void StreamFlag_SetsStreamTrue()
+    public void EndpointOverride_Captured()
     {
-        var r = Helpers.ParseArgs(["--graph", "--token", "t", "--stream"]);
+        var r = Helpers.ParseArgs(["--token", "t", "--endpoint", "https://custom.workiq.example/"]);
         Assert.Null(r.Error);
-        Assert.True(r.Stream);
+        Assert.Equal("https://custom.workiq.example/", r.Endpoint);
     }
 }

--- a/dotnet/rest/Helpers.cs
+++ b/dotnet/rest/Helpers.cs
@@ -7,7 +7,7 @@ namespace WorkIQ.Rest;
 
 public record RestArgs(
     string? Token, string? AppId, string? Account, string? Endpoint, string? Tenant,
-    bool Graph, bool Workiq, bool Stream, bool ShowToken,
+    bool Stream, bool ShowToken,
     int Verbosity, List<string> Headers, string? Error);
 
 public static class Helpers
@@ -17,7 +17,7 @@ public static class Helpers
     public static RestArgs ParseArgs(string[] args)
     {
         string? token = null, appId = null, account = null, endpoint = null, tenant = null;
-        bool graph = false, workiq = false, stream = false, showToken = false;
+        bool stream = false, showToken = false;
         int verbosity = 1;
         var headers = new List<string>();
 
@@ -25,8 +25,6 @@ public static class Helpers
         {
             switch (args[i])
             {
-                case "--graph": graph = true; break;
-                case "--workiq": workiq = true; break;
                 case "--token" or "-t":
                     if (i + 1 >= args.Length) return Err($"Missing value for {args[i]}");
                     token = args[++i]; break;
@@ -55,16 +53,16 @@ public static class Helpers
             }
         }
 
-        return new RestArgs(token, appId, account, endpoint, tenant, graph, workiq, stream, showToken, verbosity, headers, null);
+        return new RestArgs(token, appId, account, endpoint, tenant, stream, showToken, verbosity, headers, null);
 
-        static RestArgs Err(string msg) => new(null, null, null, null, null, false, false, false, false, 1, new List<string>(), msg);
+        static RestArgs Err(string msg) => new(null, null, null, null, null, false, false, 1, new List<string>(), msg);
     }
 
     // ── Chat body builder ───────────────────────────────────────────────
 
     public static string BuildChatBody(string message)
     {
-        // Graph API requires IANA timezone (e.g. "America/Los_Angeles"), not Windows (e.g. "Pacific Standard Time")
+        // The Copilot Chat API requires an IANA timezone (e.g. "America/Los_Angeles"), not Windows (e.g. "Pacific Standard Time")
         string tz;
         try { tz = TimeZoneInfo.Local.HasIanaId ? TimeZoneInfo.Local.Id : TimeZoneInfo.TryConvertWindowsIdToIanaId(TimeZoneInfo.Local.Id, out var iana) ? iana : "UTC"; }
         catch { tz = "UTC"; }

--- a/dotnet/rest/Program.cs
+++ b/dotnet/rest/Program.cs
@@ -1,6 +1,6 @@
-// WorkIQ REST Sample — Interactive Copilot Chat via Microsoft Graph or Work IQ Gateway
+// WorkIQ REST Sample — Interactive Copilot Chat via the Work IQ Gateway
 // Supports both synchronous (/chat) and streaming (/chatOverStream) modes.
-// Usage: dotnet run -- <--graph|--workiq> --token <JWT|WAM> --appid <clientId> [--endpoint <url>] [--stream] [--account <email>]
+// Usage: dotnet run -- --token <JWT|WAM> --appid <clientId> [--endpoint <url>] [--stream] [--account <email>]
 // Docs:  https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview
 
 using System.Diagnostics;
@@ -12,25 +12,19 @@ using System.Text.Json;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Broker;
 
-// Per-gateway (host, path) defaults. --endpoint overrides only the host
-// (scheme + authority); the path is fixed per gateway by its routing convention.
-const string GraphHost = "https://graph.microsoft.com";
-const string GraphPath = "/beta/copilot";
+// --endpoint overrides only the host (scheme + authority); the path is fixed.
+// Work IQ Gateway multiplexes REST/A2A/MCP at one host via path prefix
+// (/rest, /a2a, /tools). AGS Slice R strips the /rest prefix before forwarding.
 const string WorkIQDefaultHost = "https://workiq.svc.cloud.microsoft";
-// Work IQ Gateway multiplexes REST/A2A/MCP at one host via path prefix (/rest, /a2a, /tools).
-// AGS Slice R strips the /rest prefix before forwarding.
 const string WorkIQPath = "/rest/beta";
 
 var config = ParseArgs(args);
 if (config == null) return;
 
-var (defaultHost, gatewayPath) = config.Gateway == "workiq"
-    ? (WorkIQDefaultHost, WorkIQPath)
-    : (GraphHost, GraphPath);
 var host = !string.IsNullOrEmpty(config.Endpoint)
     ? config.Endpoint.TrimEnd('/')
-    : defaultHost;
-var apiBase = host + gatewayPath;
+    : WorkIQDefaultHost;
+var apiBase = host + WorkIQPath;
 
 string token;
 IPublicClientApplication? msalApp = null;
@@ -38,7 +32,7 @@ IAccount? msalAccount = null;
 
 if (config.Token.Equals("WAM", StringComparison.OrdinalIgnoreCase))
 {
-    var r = await AcquireWamToken(config.AppId, config.Account, config.Gateway, config.Tenant);
+    var r = await AcquireWamToken(config.AppId, config.Account, config.Tenant);
     token = r.token; msalApp = r.app; msalAccount = r.account;
 }
 else
@@ -66,7 +60,7 @@ string? conversationId = null;
 
 if (config.Verbosity >= 1)
 {
-    Log($"READY — {(config.Stream ? "Streaming" : "Synchronous")} mode ({config.Gateway})");
+    Log($"READY — {(config.Stream ? "Streaming" : "Synchronous")} mode (Work IQ Gateway)");
     Console.WriteLine("Type a message. 'quit' to exit.\n");
 }
 
@@ -81,7 +75,7 @@ while (true)
     {
         try
         {
-            var r = await AcquireWamToken(config.AppId, config.Account, config.Gateway, config.Tenant, msalApp, msalAccount);
+            var r = await AcquireWamToken(config.AppId, config.Account, config.Tenant, msalApp, msalAccount);
             token = r.token; msalAccount = r.account;
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         }
@@ -304,7 +298,7 @@ static string BuildChatBody(string message) => WorkIQ.Rest.Helpers.BuildChatBody
 // ── WAM auth ─────────────────────────────────────────────────────────────
 
 static async Task<(string token, IPublicClientApplication app, IAccount? account)> AcquireWamToken(
-    string clientId, string? accountHint, string gateway = "graph", string? tenantId = null,
+    string clientId, string? accountHint, string? tenantId = null,
     IPublicClientApplication? existingApp = null, IAccount? existingAccount = null)
 {
     var app = existingApp;
@@ -325,9 +319,7 @@ static async Task<(string token, IPublicClientApplication app, IAccount? account
         app = builder.Build();
     }
 
-    string[] scopes = gateway == "workiq"
-        ? ["api://workiq.svc.cloud.microsoft/.default"]
-        : ["https://graph.microsoft.com/.default"];
+    string[] scopes = ["api://workiq.svc.cloud.microsoft/.default"];
     AuthenticationResult result;
 
     try
@@ -393,20 +385,16 @@ static Config? ParseArgs(string[] args)
     }
 
     string? token = a.Token, appId = a.AppId, account = a.Account, endpoint = a.Endpoint, tenant = a.Tenant;
-    bool graph = a.Graph, workiq = a.Workiq, stream = a.Stream, showToken = a.ShowToken;
+    bool stream = a.Stream, showToken = a.ShowToken;
     int verbosity = a.Verbosity;
     var headers = a.Headers;
 
-    if (string.IsNullOrEmpty(token) || (!graph && !workiq))
+    if (string.IsNullOrEmpty(token))
     {
         Console.WriteLine("""
-            WorkIQ REST Sample — Interactive Copilot Chat via Microsoft Graph or Work IQ Gateway
+            WorkIQ REST Sample — Interactive Copilot Chat against the Work IQ Gateway
 
-            Usage: dotnet run -- <gateway> --token <JWT|WAM> --appid <clientId> [options]
-
-            Gateway (exactly one required):
-              --graph          Use Microsoft Graph API
-              --workiq         Use Work IQ Gateway (default: workiq.svc.cloud.microsoft)
+            Usage: dotnet run -- --token <JWT|WAM> --appid <clientId> [options]
 
             Auth:
               --token, -t      Bearer token or 'WAM' for Windows broker auth
@@ -417,25 +405,17 @@ static Config? ParseArgs(string[] args)
 
             Options:
               --endpoint, -e   Override the gateway host (scheme + authority only, no path).
-                               The gateway-specific path (/beta/copilot for Graph,
-                               /rest/beta for Work IQ) is appended automatically.
+                               The /rest/beta path is appended automatically.
               --header, -H     Custom HTTP header in 'Key: Value' format (repeatable)
               --stream         Use streaming mode (SSE via /chatOverStream)
               --show-token     Print the raw JWT token (for reuse)
               -v, --verbosity  0 = response only, 1 = default, 2 = full wire, 3 = all response headers
 
             Examples:
-              dotnet run -- --graph --token WAM --appid <your-app-id>
-              dotnet run -- --graph --token WAM --appid <your-app-id> --stream
-              dotnet run -- --workiq --token WAM --appid <your-app-id>
-              dotnet run -- --graph --token eyJ0eXAi...
+              dotnet run -- --token WAM --appid <your-app-id> --tenant <your-tenant>
+              dotnet run -- --token WAM --appid <your-app-id> --stream
+              dotnet run -- --token eyJ0eXAi...
             """);
-        return null;
-    }
-
-    if (graph && workiq)
-    {
-        Ink("ERROR: specify --graph or --workiq, not both\n", ConsoleColor.Red);
         return null;
     }
 
@@ -445,7 +425,7 @@ static Config? ParseArgs(string[] args)
         return null;
     }
 
-    return new Config(token, appId ?? "", account, graph ? "graph" : "workiq", endpoint, tenant, stream, showToken, verbosity, headers);
+    return new Config(token, appId ?? "", account, endpoint, tenant, stream, showToken, verbosity, headers);
 }
 
 // ── Utilities ────────────────────────────────────────────────────────────
@@ -479,7 +459,7 @@ static string Trunc(string s, int max) => WorkIQ.Rest.Helpers.Trunc(s, max);
 [DllImport("user32.dll", ExactSpelling = true)] static extern IntPtr GetAncestor(IntPtr hwnd, uint flags);
 static IntPtr ConsoleWindowHandle() { var c = Win32GetConsoleWindow(); var r = GetAncestor(c, 3); return r != IntPtr.Zero ? r : c; }
 
-record Config(string Token, string AppId, string? Account, string Gateway, string? Endpoint, string? Tenant, bool Stream, bool ShowToken, int Verbosity, List<string> Headers);
+record Config(string Token, string AppId, string? Account, string? Endpoint, string? Tenant, bool Stream, bool ShowToken, int Verbosity, List<string> Headers);
 
 // ── Diagnostic handler ──────────────────────────────────────────────────
 

--- a/dotnet/rest/Program.cs
+++ b/dotnet/rest/Program.cs
@@ -428,7 +428,6 @@ static Config? ParseArgs(string[] args)
               dotnet run -- --graph --token WAM --appid <your-app-id>
               dotnet run -- --graph --token WAM --appid <your-app-id> --stream
               dotnet run -- --workiq --token WAM --appid <your-app-id>
-              dotnet run -- --workiq --endpoint https://test.workiq.svc.cloud.dev.microsoft --token WAM --appid <your-app-id>
               dotnet run -- --graph --token eyJ0eXAi...
             """);
         return null;

--- a/dotnet/rest/README.md
+++ b/dotnet/rest/README.md
@@ -38,15 +38,6 @@ dotnet run -- --workiq --token WAM --appid <APP_ID> --tenant <TENANT_ID>
 
 Type a message, see a response, type `quit` to exit.
 
-### Against the Work IQ Gateway, a specific ring (e.g. `ppe.`)
-
-```bash
-dotnet run -- --workiq --endpoint https://ppe.workiq.svc.cloud.dev.microsoft \
-  --token WAM --appid <APP_ID> --tenant <TENANT_ID>
-```
-
-`--endpoint` takes **host-only** (scheme + authority). The sample appends `/rest/beta` automatically.
-
 ### Against Microsoft Graph
 
 ```bash

--- a/dotnet/rest/README.md
+++ b/dotnet/rest/README.md
@@ -2,17 +2,17 @@
 
 A minimal, single-file interactive client for the [Microsoft 365 Copilot Chat REST API](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview) — the REST interface for conversational AI grounded in Microsoft 365 data.
 
-Supports both **synchronous** and **streaming** (SSE) modes, against either the **Work IQ Gateway** or **Microsoft Graph**.
+Supports both **synchronous** and **streaming** (SSE) modes against the **Work IQ Gateway**.
 
 ## API reference
 
-| Operation | Method | Path (via Work IQ) | Path (via Graph) | Docs |
-|-----------|--------|--------------------|------------------|------|
-| Create conversation | `POST` | `/rest/beta/conversations` | `/beta/copilot/conversations` | [Docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotroot-post-conversations) |
-| Chat (sync) | `POST` | `/rest/beta/conversations/{id}/chat` | `/beta/copilot/conversations/{id}/chat` | [Docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat) |
-| Chat (stream) | `POST` | `/rest/beta/conversations/{id}/chatOverStream` | `/beta/copilot/conversations/{id}/chatOverStream` | [Docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chatoverstream) |
+| Operation | Method | Path | Docs |
+|-----------|--------|------|------|
+| Create conversation | `POST` | `/rest/beta/conversations` | [Docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotroot-post-conversations) |
+| Chat (sync) | `POST` | `/rest/beta/conversations/{id}/chat` | [Docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chat) |
+| Chat (stream) | `POST` | `/rest/beta/conversations/{id}/chatOverStream` | [Docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/copilotconversation-chatoverstream) |
 
-The sample appends the gateway-specific path to `--endpoint` automatically. You only need to supply the host.
+The sample appends `/rest/beta` to `--endpoint` automatically. You only need to supply the host.
 
 ## Prerequisites
 
@@ -21,37 +21,31 @@ The sample appends the gateway-specific path to `--endpoint` automatically. You 
    - If you're the tenant admin:
      ```bash
      # Bash
-     ../../scripts/admin-setup.sh --workiq    # or --graph or --both
+     ../../scripts/admin-setup.sh
      # PowerShell
-     ..\..\scripts\admin-setup.ps1 -Gateway WorkIQ
+     ..\..\scripts\admin-setup.ps1
      ```
    - Otherwise, hand [`../../ADMIN_SETUP.md`](../../ADMIN_SETUP.md) to your admin. They'll give you an **App ID** and **Tenant ID**.
 3. **.NET 10 SDK** or later — [download](https://dotnet.microsoft.com/download/dotnet/10.0).
 
 ## Quick start
 
-### Against the Work IQ Gateway (default host `workiq.svc.cloud.microsoft`)
+### Default — talk to the Work IQ Gateway
 
 ```bash
-dotnet run -- --workiq --token WAM --appid <APP_ID> --tenant <TENANT_ID>
+dotnet run -- --token WAM --appid <APP_ID> --tenant <TENANT_ID>
 ```
 
 Type a message, see a response, type `quit` to exit.
 
-### Against Microsoft Graph
-
-```bash
-dotnet run -- --graph --token WAM --appid <APP_ID> --tenant <TENANT_ID>
-```
-
 ### Streaming mode
 
-Add `--stream` to any of the above to switch from `/chat` (sync) to `/chatOverStream` (SSE).
+Add `--stream` to switch from `/chat` (sync) to `/chatOverStream` (SSE).
 
 ### With a pre-obtained JWT (any platform)
 
 ```bash
-dotnet run -- --graph --token eyJ0eXAi...
+dotnet run -- --token eyJ0eXAi...
 ```
 
 > **macOS / Linux users:** WAM is only available on Windows. Use `--token <JWT>` with a pre-obtained token instead.
@@ -67,7 +61,7 @@ dotnet run -- --graph --token eyJ0eXAi...
   scp              WorkIQAgent.Ask
   expires          ...
 
-── READY — Synchronous mode (workiq) ──
+── READY — Synchronous mode (Work IQ Gateway) ──
 Type a message. 'quit' to exit.
 
 You > What's on my calendar today?
@@ -81,13 +75,12 @@ Agent > Here's your schedule:
 You > quit
 ```
 
-If the `── TOKEN ──` block shows an `aud` matching the gateway and `scp` matching the required scope(s), your auth is working.
+If the `── TOKEN ──` block shows `aud` matching the Work IQ Gateway and `scp` includes `WorkIQAgent.Ask`, your auth is working.
 
 ## Flags
 
 | Flag | Description |
 |------|-------------|
-| `--graph` / `--workiq` | Gateway selection. Exactly one required. |
 | `--token, -t` | `WAM` for Windows broker auth, or a pre-obtained JWT string |
 | `--appid, -a` | Entra app client ID (required with `WAM`) |
 | `--tenant, -T` | Tenant ID or domain. Required with `WAM` for single-tenant apps; defaults to `common` for multi-tenant. |
@@ -178,7 +171,6 @@ data: { "id": "conv-123", "messages": [{ "text": "You have 3 meetings scheduled.
 
 - **No external SDK required.** Unlike the A2A sample, this calls the REST API directly with `HttpClient`. Just JSON over HTTP.
 - **Streaming is cumulative, not incremental.** Each SSE event contains the full conversation state. The sample computes deltas by diffing against the previous text.
-- **Graph Explorer doesn't support streaming.** Per [Microsoft docs](https://learn.microsoft.com/en-us/microsoft-365-copilot/extensibility/api/ai-services/chat/overview#known-limitations), use this sample or curl instead.
 
 ## NuGet dependencies
 
@@ -188,15 +180,14 @@ data: { "id": "conv-123", "messages": [{ "text": "You have 3 meetings scheduled.
 | `Microsoft.Identity.Client.Broker` | Windows WAM broker |
 | `System.IdentityModel.Tokens.Jwt` | JWT decoding for diagnostics |
 
-No A2A SDK or Graph SDK needed — pure `HttpClient` + JSON.
+No A2A SDK needed — pure `HttpClient` + JSON.
 
 ## Sample-specific troubleshooting
 
 | Symptom | Fix |
 |---------|-----|
-| `400 Invalid request, no valid route` against Work IQ | Pass `--endpoint` as host-only; the sample appends the correct path |
-| `403 Required scopes = [Sites.Read.All, ...]` against Graph | Admin needs to add the 7 Copilot Graph permissions. Run `scripts/admin-setup.sh --graph` |
-| `401 Unauthorized` | Token audience doesn't match the gateway. Verify the `aud` claim in the `── TOKEN ──` block matches the gateway you picked. |
+| `400 Invalid request, no valid route` | Pass `--endpoint` as host-only; the sample appends `/rest/beta` |
+| `401 Unauthorized` | Token audience doesn't match the Work IQ Gateway. Verify the `aud` claim in the `── TOKEN ──` block. |
 
 See the [root README](../../README.md#troubleshooting) for the full troubleshooting matrix (WAM setup, single-tenant apps, Copilot license, etc).
 

--- a/dotnet/rest/rest.sln
+++ b/dotnet/rest/rest.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "workiq-rest-sample", "workiq-rest-sample.csproj", "{638D0555-FA16-E236-6E50-7C38D5AD0FFD}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{638D0555-FA16-E236-6E50-7C38D5AD0FFD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{638D0555-FA16-E236-6E50-7C38D5AD0FFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{638D0555-FA16-E236-6E50-7C38D5AD0FFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{638D0555-FA16-E236-6E50-7C38D5AD0FFD}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {867C2818-3E00-4226-BAEE-9B5EE72B3DF6}
+	EndGlobalSection
+EndGlobal

--- a/scripts/admin-setup.ps1
+++ b/scripts/admin-setup.ps1
@@ -4,14 +4,11 @@
 
 .DESCRIPTION
   Creates a public-client Entra app registration with the permissions the
-  .NET samples need. Idempotent: re-running against an existing app name
-  updates it (after confirmation) instead of creating a duplicate.
+  .NET samples need (Work IQ Gateway). Idempotent: re-running against an
+  existing app name updates it (after confirmation) instead of creating
+  a duplicate.
 
   Requires: Azure CLI, logged in as tenant admin (az login).
-
-.PARAMETER Gateway
-  Which gateway's permissions to configure: WorkIQ, Graph, or Both.
-  Default: WorkIQ.
 
 .PARAMETER Name
   Display name for the app registration. Default: "Work IQ Samples Client".
@@ -30,10 +27,10 @@
   Echo each az command before running it.
 
 .EXAMPLE
-  .\admin-setup.ps1 -Gateway WorkIQ
+  .\admin-setup.ps1
 
 .EXAMPLE
-  .\admin-setup.ps1 -Gateway Both -Name "My Samples App" -MultiTenant
+  .\admin-setup.ps1 -Name "My Samples App" -MultiTenant
 
 .NOTES
   For the Swift iOS sample, use swift/a2a/setup-app-registration.ps1
@@ -42,9 +39,6 @@
 
 [CmdletBinding()]
 param(
-    [ValidateSet('WorkIQ', 'Graph', 'Both')]
-    [string]$Gateway = 'WorkIQ',
-
     [string]$Name = 'Work IQ Samples Client',
 
     [string]$Tenant = '',
@@ -59,20 +53,8 @@ param(
 $ErrorActionPreference = 'Stop'
 
 # ── Well-known IDs ──────────────────────────────────────────────────────
-$GraphAppId = '00000003-0000-0000-c000-000000000000'
 $WorkIqAppId = 'fdcc1f02-fc51-4226-8753-f668596af7f7'
 $WorkIqAgentAskScopeId = '0b1715fd-f4bf-4c63-b16d-5be31f9847c2'
-
-# Graph delegated-permission GUIDs (required for the Copilot Chat API)
-$GraphScopes = @(
-    '205e70e5-aba6-4c52-a976-6d2d46c48043'  # Sites.Read.All
-    '570282fd-fa5c-430d-a7fd-fc8dc98a9dca'  # Mail.Read
-    'b89f9189-71a5-4e70-b041-9887f0bc7e4a'  # People.Read.All
-    '30b87d18-ebb1-45db-97f8-82ccb1f0190c'  # OnlineMeetingTranscript.Read.All
-    'f501c180-9344-439a-bca0-6cbf209fd270'  # Chat.Read
-    '767156cb-16ae-4d10-8f8b-41b657c8c8c8'  # ChannelMessage.Read.All
-    '922f9392-b1b7-483c-a4be-0089be7704fb'  # ExternalItem.Read.All
-)
 
 $signInAudience = if ($MultiTenant) { 'AzureADMultipleOrgs' } else { 'AzureADMyOrg' }
 
@@ -115,21 +97,18 @@ Write-Host 'Work IQ Samples — Admin Setup'
 Write-Host "  Tenant:           $Tenant"
 Write-Host "  Signed in as:     $currentUser"
 Write-Host "  App name:         $Name"
-Write-Host "  Gateway:          $Gateway"
 Write-Host "  Sign-in audience: $signInAudience"
 if ($DryRun) { Write-Host '  [DRY RUN — no changes will be made]' -ForegroundColor Yellow }
 Write-Host ''
 
 # ── Step 1: Work IQ SP JIT-provisioning ─────────────────────────────────
-if ($Gateway -in 'WorkIQ', 'Both') {
-    Write-Host '[1/6] Ensuring Work IQ service principal exists in tenant...'
-    try {
-        Invoke-Step @('az', 'ad', 'sp', 'create', '--id', $WorkIqAppId) | Out-Null
-    } catch {
-        # Harmless if the SP already exists
-    }
-    Write-Host '      OK'
+Write-Host '[1/6] Ensuring Work IQ service principal exists in tenant...'
+try {
+    Invoke-Step @('az', 'ad', 'sp', 'create', '--id', $WorkIqAppId) | Out-Null
+} catch {
+    # Harmless if the SP already exists
 }
+Write-Host '      OK'
 
 # ── Step 2: Create or reuse app registration ────────────────────────────
 Write-Host '[2/6] Creating app registration...'
@@ -171,23 +150,13 @@ Invoke-Step @('az', 'ad', 'app', 'update',
 Write-Host '      OK'
 
 # ── Step 5: Delegated permissions ───────────────────────────────────────
-Write-Host "[5/6] Adding delegated permissions ($Gateway)..."
-if ($Gateway -in 'Graph', 'Both') {
-    $graphArgs = @('az', 'ad', 'app', 'permission', 'add', '--id', $appId, '--api', $GraphAppId, '--api-permissions')
-    foreach ($id in $GraphScopes) { $graphArgs += "$id=Scope" }
-    try { Invoke-Step $graphArgs | Out-Null } catch { }
-    Write-Host '      Graph: Sites.Read.All, Mail.Read, People.Read.All,'
-    Write-Host '             OnlineMeetingTranscript.Read.All, Chat.Read,'
-    Write-Host '             ChannelMessage.Read.All, ExternalItem.Read.All'
-}
-if ($Gateway -in 'WorkIQ', 'Both') {
-    try {
-        Invoke-Step @('az', 'ad', 'app', 'permission', 'add',
-            '--id', $appId, '--api', $WorkIqAppId,
-            '--api-permissions', "$WorkIqAgentAskScopeId=Scope") | Out-Null
-    } catch { }
-    Write-Host '      Work IQ: WorkIQAgent.Ask'
-}
+Write-Host '[5/6] Adding delegated permissions...'
+try {
+    Invoke-Step @('az', 'ad', 'app', 'permission', 'add',
+        '--id', $appId, '--api', $WorkIqAppId,
+        '--api-permissions', "$WorkIqAgentAskScopeId=Scope") | Out-Null
+} catch { }
+Write-Host '      Work IQ: WorkIQAgent.Ask'
 
 # ── Step 6: Admin consent (direct Microsoft Graph API, idempotent) ─────
 # We deliberately do NOT use 'az ad app permission admin-consent' — it uses
@@ -246,17 +215,9 @@ function Set-Grant {
 
 Write-Host '[6/6] Granting admin consent (direct Graph API)...'
 $appSpId = Resolve-SpId -AppId $appId
-if ($Gateway -in 'Graph', 'Both') {
-    $graphSpId = Resolve-SpId -AppId $GraphAppId
-    Set-Grant -ClientSpId $appSpId -ResourceSpId $graphSpId `
-        -Scopes 'Sites.Read.All Mail.Read People.Read.All OnlineMeetingTranscript.Read.All Chat.Read ChannelMessage.Read.All ExternalItem.Read.All'
-    Write-Host '      Graph: consent granted'
-}
-if ($Gateway -in 'WorkIQ', 'Both') {
-    $workIqSpId = Resolve-SpId -AppId $WorkIqAppId
-    Set-Grant -ClientSpId $appSpId -ResourceSpId $workIqSpId -Scopes 'WorkIQAgent.Ask'
-    Write-Host '      Work IQ: consent granted'
-}
+$workIqSpId = Resolve-SpId -AppId $WorkIqAppId
+Set-Grant -ClientSpId $appSpId -ResourceSpId $workIqSpId -Scopes 'WorkIQAgent.Ask'
+Write-Host '      Work IQ: consent granted'
 
 # ── Summary ─────────────────────────────────────────────────────────────
 Write-Host ''
@@ -267,17 +228,10 @@ Write-Host "  APP_ID:    $appId"
 Write-Host "  TENANT_ID: $Tenant"
 Write-Host ''
 Write-Host 'Test commands:'
-if ($Gateway -in 'WorkIQ', 'Both') {
-    Write-Host '  # WorkIQ REST (Copilot Chat via WorkIQ Gateway):'
-    Write-Host "  cd dotnet/rest; dotnet run -- --workiq --token WAM ``"
-    Write-Host "      --appid $appId --tenant $Tenant"
-    Write-Host ''
-    Write-Host '  # WorkIQ A2A:'
-    Write-Host "  cd dotnet/a2a; dotnet run -- --workiq --token WAM ``"
-    Write-Host "      --appid $appId --tenant $Tenant"
-}
-if ($Gateway -in 'Graph', 'Both') {
-    Write-Host '  # Graph RP (Copilot Chat via Microsoft Graph):'
-    Write-Host "  cd dotnet/rest; dotnet run -- --graph --token WAM ``"
-    Write-Host "      --appid $appId --tenant $Tenant"
-}
+Write-Host '  # Work IQ REST (Copilot Chat via Work IQ Gateway):'
+Write-Host "  cd dotnet/rest; dotnet run -- --token WAM ``"
+Write-Host "      --appid $appId --tenant $Tenant"
+Write-Host ''
+Write-Host '  # Work IQ A2A:'
+Write-Host "  cd dotnet/a2a; dotnet run -- --token WAM ``"
+Write-Host "      --appid $appId --tenant $Tenant"

--- a/scripts/admin-setup.sh
+++ b/scripts/admin-setup.sh
@@ -4,42 +4,31 @@ set -euo pipefail
 # Work IQ Samples — App Registration Setup (Admin script)
 #
 # Creates a public-client Entra app registration with the permissions the
-# .NET samples need. Idempotent: re-running against an existing app name
-# updates it (after confirmation) instead of creating a duplicate.
+# .NET samples need (Work IQ Gateway). Idempotent: re-running against an
+# existing app name updates it (after confirmation) instead of creating
+# a duplicate.
 #
 # Requires: Azure CLI, logged in as tenant admin (az login).
 #
 # Usage:
-#   ./admin-setup.sh [--workiq|--graph|--both] [--name <NAME>]
-#                    [--tenant <TENANT_ID>] [--multi-tenant]
-#                    [--dry-run] [--verbose] [-h|--help]
+#   ./admin-setup.sh [--name <NAME>] [--tenant <TENANT_ID>]
+#                    [--multi-tenant] [--dry-run] [--verbose] [-h|--help]
 #
-# Defaults: --workiq, name "Work IQ Samples Client", single-tenant.
+# Defaults: name "Work IQ Samples Client", single-tenant.
 #
 # For the Swift iOS sample, use swift/a2a/setup-app-registration.sh
 # (needs an iOS-specific redirect URI).
 
 # ── Defaults ────────────────────────────────────────────────────────────
 DISPLAY_NAME="Work IQ Samples Client"
-GATEWAY="workiq"                  # workiq | graph | both
 SIGN_IN_AUDIENCE="AzureADMyOrg"   # single-tenant
 TENANT_ID=""
 DRY_RUN="false"
 VERBOSE="false"
 
 # ── Well-known IDs ──────────────────────────────────────────────────────
-GRAPH_APP_ID="00000003-0000-0000-c000-000000000000"
 WORKIQ_APP_ID="fdcc1f02-fc51-4226-8753-f668596af7f7"
 WORKIQ_AGENT_ASK_SCOPE_ID="0b1715fd-f4bf-4c63-b16d-5be31f9847c2"
-
-# Graph delegated-permission GUIDs (required for the Copilot Chat API)
-GRAPH_SITES_READ_ALL="205e70e5-aba6-4c52-a976-6d2d46c48043"
-GRAPH_MAIL_READ="570282fd-fa5c-430d-a7fd-fc8dc98a9dca"
-GRAPH_PEOPLE_READ_ALL="b89f9189-71a5-4e70-b041-9887f0bc7e4a"
-GRAPH_ONLINE_MEETING_TRANSCRIPT_READ_ALL="30b87d18-ebb1-45db-97f8-82ccb1f0190c"
-GRAPH_CHAT_READ="f501c180-9344-439a-bca0-6cbf209fd270"
-GRAPH_CHANNEL_MESSAGE_READ_ALL="767156cb-16ae-4d10-8f8b-41b657c8c8c8"
-GRAPH_EXTERNAL_ITEM_READ_ALL="922f9392-b1b7-483c-a4be-0089be7704fb"
 
 # ── CLI parsing ─────────────────────────────────────────────────────────
 show_help() {
@@ -48,9 +37,6 @@ show_help() {
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --graph) GATEWAY="graph"; shift ;;
-    --workiq) GATEWAY="workiq"; shift ;;
-    --both) GATEWAY="both"; shift ;;
     --multi-tenant) SIGN_IN_AUDIENCE="AzureADMultipleOrgs"; shift ;;
     --name) DISPLAY_NAME="$2"; shift 2 ;;
     --tenant) TENANT_ID="$2"; shift 2 ;;
@@ -91,18 +77,15 @@ echo "Work IQ Samples — Admin Setup"
 echo "  Tenant:         $TENANT_ID"
 echo "  Signed in as:   $CURRENT_USER"
 echo "  App name:       $DISPLAY_NAME"
-echo "  Gateway:        $GATEWAY"
 echo "  Sign-in audience: $SIGN_IN_AUDIENCE"
 if [[ "$DRY_RUN" == "true" ]]; then echo "  [DRY RUN — no changes will be made]"; fi
 echo ""
 
 # ── Step 1: Work IQ SP JIT-provisioning ─────────────────────────────────
-if [[ "$GATEWAY" == "workiq" || "$GATEWAY" == "both" ]]; then
-  echo "[1/6] Ensuring Work IQ service principal exists in tenant..."
-  # Idempotent: harmless if it already exists
-  run az ad sp create --id "$WORKIQ_APP_ID" >/dev/null 2>&1 || true
-  echo "      OK"
-fi
+echo "[1/6] Ensuring Work IQ service principal exists in tenant..."
+# Idempotent: harmless if it already exists
+run az ad sp create --id "$WORKIQ_APP_ID" >/dev/null 2>&1 || true
+echo "      OK"
 
 # ── Step 2: Create or reuse app registration ────────────────────────────
 echo "[2/6] Creating app registration..."
@@ -148,28 +131,11 @@ run az ad app update --id "$APP_ID" \
 echo "      OK"
 
 # ── Step 5: Delegated permissions ───────────────────────────────────────
-echo "[5/6] Adding delegated permissions ($GATEWAY)..."
-if [[ "$GATEWAY" == "graph" || "$GATEWAY" == "both" ]]; then
-  run az ad app permission add --id "$APP_ID" --api "$GRAPH_APP_ID" \
-    --api-permissions \
-      "${GRAPH_SITES_READ_ALL}=Scope" \
-      "${GRAPH_MAIL_READ}=Scope" \
-      "${GRAPH_PEOPLE_READ_ALL}=Scope" \
-      "${GRAPH_ONLINE_MEETING_TRANSCRIPT_READ_ALL}=Scope" \
-      "${GRAPH_CHAT_READ}=Scope" \
-      "${GRAPH_CHANNEL_MESSAGE_READ_ALL}=Scope" \
-      "${GRAPH_EXTERNAL_ITEM_READ_ALL}=Scope" \
-    2>/dev/null || true
-  echo "      Graph: Sites.Read.All, Mail.Read, People.Read.All,"
-  echo "             OnlineMeetingTranscript.Read.All, Chat.Read,"
-  echo "             ChannelMessage.Read.All, ExternalItem.Read.All"
-fi
-if [[ "$GATEWAY" == "workiq" || "$GATEWAY" == "both" ]]; then
-  run az ad app permission add --id "$APP_ID" --api "$WORKIQ_APP_ID" \
-    --api-permissions "${WORKIQ_AGENT_ASK_SCOPE_ID}=Scope" \
-    2>/dev/null || true
-  echo "      Work IQ: WorkIQAgent.Ask"
-fi
+echo "[5/6] Adding delegated permissions..."
+run az ad app permission add --id "$APP_ID" --api "$WORKIQ_APP_ID" \
+  --api-permissions "${WORKIQ_AGENT_ASK_SCOPE_ID}=Scope" \
+  2>/dev/null || true
+echo "      Work IQ: WorkIQAgent.Ask"
 
 # ── Step 6: Admin consent (direct Microsoft Graph API, idempotent) ─────
 # We deliberately do NOT use 'az ad app permission admin-consent' — it uses
@@ -218,17 +184,9 @@ resolve_sp_id() {
 
 echo "[6/6] Granting admin consent (direct Graph API)..."
 APP_SP_ID=$(resolve_sp_id "$APP_ID")
-if [[ "$GATEWAY" == "graph" || "$GATEWAY" == "both" ]]; then
-  GRAPH_SP_ID=$(resolve_sp_id "$GRAPH_APP_ID")
-  ensure_grant "$APP_SP_ID" "$GRAPH_SP_ID" \
-    "Sites.Read.All Mail.Read People.Read.All OnlineMeetingTranscript.Read.All Chat.Read ChannelMessage.Read.All ExternalItem.Read.All"
-  echo "      Graph: consent granted"
-fi
-if [[ "$GATEWAY" == "workiq" || "$GATEWAY" == "both" ]]; then
-  WORKIQ_SP_ID=$(resolve_sp_id "$WORKIQ_APP_ID")
-  ensure_grant "$APP_SP_ID" "$WORKIQ_SP_ID" "WorkIQAgent.Ask"
-  echo "      Work IQ: consent granted"
-fi
+WORKIQ_SP_ID=$(resolve_sp_id "$WORKIQ_APP_ID")
+ensure_grant "$APP_SP_ID" "$WORKIQ_SP_ID" "WorkIQAgent.Ask"
+echo "      Work IQ: consent granted"
 
 # ── Summary ─────────────────────────────────────────────────────────────
 echo ""
@@ -239,17 +197,10 @@ echo "  APP_ID:    $APP_ID"
 echo "  TENANT_ID: $TENANT_ID"
 echo ""
 echo "Test commands:"
-if [[ "$GATEWAY" == "workiq" || "$GATEWAY" == "both" ]]; then
-  echo "  # WorkIQ REST (Copilot Chat via WorkIQ Gateway):"
-  echo "  cd dotnet/rest && dotnet run -- --workiq --token WAM \\"
-  echo "      --appid $APP_ID --tenant $TENANT_ID"
-  echo ""
-  echo "  # WorkIQ A2A:"
-  echo "  cd dotnet/a2a && dotnet run -- --workiq --token WAM \\"
-  echo "      --appid $APP_ID --tenant $TENANT_ID"
-fi
-if [[ "$GATEWAY" == "graph" || "$GATEWAY" == "both" ]]; then
-  echo "  # Graph RP (Copilot Chat via Microsoft Graph):"
-  echo "  cd dotnet/rest && dotnet run -- --graph --token WAM \\"
-  echo "      --appid $APP_ID --tenant $TENANT_ID"
-fi
+echo "  # Work IQ REST (Copilot Chat via Work IQ Gateway):"
+echo "  cd dotnet/rest && dotnet run -- --token WAM \\"
+echo "      --appid $APP_ID --tenant $TENANT_ID"
+echo ""
+echo "  # Work IQ A2A:"
+echo "  cd dotnet/a2a && dotnet run -- --token WAM \\"
+echo "      --appid $APP_ID --tenant $TENANT_ID"

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 #   --appid <guid>       Existing App ID (requires --skip-setup)
 #   --keep-app           Don't delete the app on exit
 #   --log-dir <path>     Where to write per-run logs (default: ./test-logs)
+#   --agent-id <id>      Pass --agent-id to a2a + a2a-raw runs (REST ignores it)
 
 # ── Defaults ────────────────────────────────────────────────────────────
 ACCOUNT=""
@@ -40,6 +41,7 @@ SKIP_SETUP="false"
 APP_ID=""
 KEEP_APP="false"
 LOG_DIR="./test-logs"
+AGENT_ID=""
 
 # ── CLI parsing ─────────────────────────────────────────────────────────
 show_help() { sed -n '3,29p' "$0" | sed 's/^# \{0,1\}//'; }
@@ -57,6 +59,7 @@ while [[ $# -gt 0 ]]; do
     --appid) APP_ID="$2"; shift 2 ;;
     --keep-app) KEEP_APP="true"; shift ;;
     --log-dir) LOG_DIR="$2"; shift 2 ;;
+    --agent-id) AGENT_ID="$2"; shift 2 ;;
     -h|--help) show_help; exit 0 ;;
     *) echo "Unknown flag: $1" >&2; show_help; exit 1 ;;
   esac
@@ -213,6 +216,10 @@ run_sample() {
   local stream_flag=""
   [[ "$mode" == "stream" ]] && stream_flag="--stream"
 
+  # When --agent-id is provided, append it to a2a / a2a-raw commands (REST doesn't support it)
+  local agent_flag=""
+  [[ -n "$AGENT_ID" && "$sample" != "rest" ]] && agent_flag="--agent-id $AGENT_ID"
+
   local cmd
   case "$sample" in
     rest|a2a)
@@ -223,6 +230,7 @@ run_sample() {
            --tenant "$TENANT_ID"
            --account "$ACCOUNT"
            $stream_flag
+           $agent_flag
            -v 2)
       ;;
     a2a-raw)
@@ -235,7 +243,8 @@ run_sample() {
              --appid "$APP_ID"
              --tenant "$TENANT_ID"
              --account "$ACCOUNT"
-             $stream_flag)
+             $stream_flag
+             $agent_flag)
       else
         # workiq: defaults are correct
         cmd=(dotnet run --project "$project" --
@@ -243,7 +252,8 @@ run_sample() {
              --appid "$APP_ID"
              --tenant "$TENANT_ID"
              --account "$ACCOUNT"
-             $stream_flag)
+             $stream_flag
+             $agent_flag)
       fi
       ;;
     *)

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -4,20 +4,19 @@ set -euo pipefail
 # Work IQ Samples — End-to-End Test Script
 #
 # Creates a fresh app registration via admin-setup.sh, then runs each
-# .NET sample across the full (gateway, mode) matrix and deletes the app
-# on exit. Each invocation is interactive: send a message when prompted,
-# type 'quit' to move on to the next.
+# .NET sample across the (mode) matrix against the Work IQ Gateway and
+# deletes the app on exit. Each invocation is interactive: send a
+# message when prompted, type 'quit' to move on to the next.
 #
 # Requires: Azure CLI (logged in), .NET 10 SDK.
 #
 # Usage:
 #   scripts/test-e2e.sh --account user@tenant.com
-#   scripts/test-e2e.sh --account user@tenant.com --gateway workiq --modes sync
+#   scripts/test-e2e.sh --account user@tenant.com --modes sync
 #   scripts/test-e2e.sh --account user@tenant.com --samples rest,a2a --keep-app
 #
 # Flags:
 #   --account <email>    Required. The user signing in via WAM.
-#   --gateway <g>        graph | workiq | both (default: both)
 #   --samples <list>     Comma-separated: rest,a2a,a2a-raw (default: all)
 #   --modes <list>       Comma-separated: sync,stream (default: both)
 #   --name <name>        App display name (default: "WIQ E2E Test <timestamp>")
@@ -31,7 +30,6 @@ set -euo pipefail
 
 # ── Defaults ────────────────────────────────────────────────────────────
 ACCOUNT=""
-GATEWAY="both"
 SAMPLES="rest,a2a,a2a-raw"
 MODES="sync,stream"
 APP_NAME="WIQ E2E Test $(date +%Y%m%d-%H%M%S)"
@@ -49,7 +47,6 @@ show_help() { sed -n '3,29p' "$0" | sed 's/^# \{0,1\}//'; }
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --account) ACCOUNT="$2"; shift 2 ;;
-    --gateway) GATEWAY="$2"; shift 2 ;;
     --samples) SAMPLES="$2"; shift 2 ;;
     --modes) MODES="$2"; shift 2 ;;
     --name) APP_NAME="$2"; shift 2 ;;
@@ -128,7 +125,6 @@ trap 'cleanup 130' INT TERM
 echo "Work IQ Samples — End-to-End Test"
 echo "  Tenant:    $TENANT_ID"
 echo "  Account:   $ACCOUNT"
-echo "  Gateway:   $GATEWAY"
 echo "  Samples:   $SAMPLES"
 echo "  Modes:     $MODES"
 echo "  App name:  $APP_NAME"
@@ -140,14 +136,7 @@ if [[ "$SKIP_SETUP" == "true" ]]; then
   echo "── Step 1: Using existing app $APP_ID (--skip-setup) ──"
 else
   echo "── Step 1: Creating app registration via admin-setup.sh ──"
-  # admin-setup needs all perms for the full matrix
-  SETUP_GATEWAY="$GATEWAY"
-  if [[ "$GATEWAY" != "both" ]]; then
-    SETUP_GATEWAY="$GATEWAY"
-  else
-    SETUP_GATEWAY="both"
-  fi
-  "$SCRIPT_DIR/admin-setup.sh" --$SETUP_GATEWAY --name "$APP_NAME" --tenant "$TENANT_ID" 2>&1 | tee "$LOG_DIR/00-admin-setup.log" | tail -30
+  "$SCRIPT_DIR/admin-setup.sh" --name "$APP_NAME" --tenant "$TENANT_ID" 2>&1 | tee "$LOG_DIR/00-admin-setup.log" | tail -30
   APP_ID=$(az ad app list --display-name "$APP_NAME" --query "[0].appId" -o tsv)
   if [[ -z "$APP_ID" ]]; then
     echo "ERROR: Could not look up created App ID by name '$APP_NAME'." >&2
@@ -171,19 +160,12 @@ echo ""
 # Parse comma-separated lists into bash arrays
 IFS=',' read -ra SAMPLE_ARR <<<"$SAMPLES"
 IFS=',' read -ra MODE_ARR <<<"$MODES"
-if [[ "$GATEWAY" == "both" ]]; then
-  GATEWAY_ARR=("graph" "workiq")
-else
-  GATEWAY_ARR=("$GATEWAY")
-fi
 
 # Pre-compute totals for nice counters
 TOTAL=0
 for s in "${SAMPLE_ARR[@]}"; do
-  for g in "${GATEWAY_ARR[@]}"; do
-    for m in "${MODE_ARR[@]}"; do
-      TOTAL=$((TOTAL + 1))
-    done
+  for m in "${MODE_ARR[@]}"; do
+    TOTAL=$((TOTAL + 1))
   done
 done
 
@@ -205,11 +187,10 @@ FAILED=()
 
 run_sample() {
   local sample="$1"
-  local gateway="$2"
-  local mode="$3"
+  local mode="$2"
   RUN_IDX=$((RUN_IDX + 1))
-  local label="$RUN_IDX/$TOTAL  $sample / $gateway / $mode"
-  local log_file="$LOG_DIR/$(printf '%02d' $RUN_IDX)-${sample}-${gateway}-${mode}.log"
+  local label="$RUN_IDX/$TOTAL  $sample / $mode"
+  local log_file="$LOG_DIR/$(printf '%02d' $RUN_IDX)-${sample}-${mode}.log"
 
   # Build the command per sample
   local project="$REPO_ROOT/dotnet/$sample"
@@ -222,39 +203,14 @@ run_sample() {
 
   local cmd
   case "$sample" in
-    rest|a2a)
+    rest|a2a|a2a-raw)
       cmd=(dotnet run --project "$project" --
-           --$gateway
            --token WAM
            --appid "$APP_ID"
            --tenant "$TENANT_ID"
            --account "$ACCOUNT"
            $stream_flag
-           $agent_flag
-           -v 2)
-      ;;
-    a2a-raw)
-      # a2a-raw takes --endpoint + --scope directly; no --graph/--workiq flag
-      if [[ "$gateway" == "graph" ]]; then
-        cmd=(dotnet run --project "$project" --
-             --endpoint "https://graph.microsoft.com/rp/workiq/"
-             --scope "https://graph.microsoft.com/.default"
-             --token WAM
-             --appid "$APP_ID"
-             --tenant "$TENANT_ID"
-             --account "$ACCOUNT"
-             $stream_flag
-             $agent_flag)
-      else
-        # workiq: defaults are correct
-        cmd=(dotnet run --project "$project" --
-             --token WAM
-             --appid "$APP_ID"
-             --tenant "$TENANT_ID"
-             --account "$ACCOUNT"
-             $stream_flag
-             $agent_flag)
-      fi
+           $agent_flag)
       ;;
     *)
       echo "  SKIP: unknown sample '$sample'" >&2
@@ -297,10 +253,8 @@ run_sample() {
 }
 
 for sample in "${SAMPLE_ARR[@]}"; do
-  for gateway in "${GATEWAY_ARR[@]}"; do
-    for mode in "${MODE_ARR[@]}"; do
-      run_sample "$sample" "$gateway" "$mode"
-    done
+  for mode in "${MODE_ARR[@]}"; do
+    run_sample "$sample" "$mode"
   done
 done
 


### PR DESCRIPTION
 ## Summary

  - **`--agent-id <id>`** on both `a2a` (SDK) and `a2a-raw` (raw HTTP) samples. The SDK sample uses `A2ACardResolver` to fetch `{gateway}/{agent-id}/.well-known/agent-card.json` and posts to
  `agentCard.url`; the raw sample mirrors this with `HttpClient` + `JsonDocument`. Both fall back to `message/send` if `--stream` is set but the agent's card reports no streaming capability.
  - **`--list-agents`** on both samples. GETs `{endpoint}/.agents` (a Work IQ / Sydney extension — same endpoint workiqcli uses), parses the `{agentId, name, provider}` array, prints a
  column-aligned table, exits. Useful for discovering IDs to pass to `--agent-id` without leaving the sample.
  - **Remove internal dev-ring URLs** (`ppe.workiq.svc.cloud.dev.microsoft`, `test.workiq.svc.cloud.dev.microsoft`) from customer-facing READMEs and help text. The `--endpoint` override capability
  is unchanged — only the documented examples and ring-specific README sections are removed.

  ## Test plan

  - [x] 29 unit tests pass on `a2a` (3 new for `--list-agents`)
  - [x] 32 unit tests pass on `a2a-raw` (3 new for `--list-agents`)
  - [x] `dotnet build` clean on `a2a`, `a2a-raw`, `rest`
  - [x] `--agent-id` verified end-to-end against an MCS-published CEA on the Work IQ Gateway
  - [x] No remaining `ppe.workiq` / `test.workiq` references in `*.md`, `*.cs`, `*.sh`, `*.ps1`
  - [ ] `--list-agents` verified end-to-end (will run after merge)

  Three commits, all already pushed:
  - 632ff90 — --agent-id
  - 7a935c5 — internal-URL cleanup
  - 498bcdc — --list-agents