### PR TITLE
Add streaming support to A2A samples

### DIFF
--- a/dotnet/a2a-raw.tests/ArgParsingTests.cs
+++ b/dotnet/a2a-raw.tests/ArgParsingTests.cs
@@ -15,11 +15,12 @@ public class ArgParsingTests
     [Fact]
     public void ValidArgs_AllParsedCorrectly()
     {
-        var r = Helpers.ParseArgs(["--endpoint", "https://example.com", "--token", "abc", "--appid", "id1"]);
+        var r = Helpers.ParseArgs(["--endpoint", "https://example.com", "--token", "abc", "--appid", "id1", "--stream"]);
         Assert.Null(r.Error);
         Assert.Equal("https://example.com", r.Endpoint);
         Assert.Equal("abc", r.Token);
         Assert.Equal("id1", r.AppId);
+        Assert.True(r.Stream);
     }
 
     [Fact]
@@ -38,15 +39,6 @@ public class ArgParsingTests
         var r = Helpers.ParseArgs(["--unknown"]);
         Assert.NotNull(r.Error);
         Assert.Contains("Unknown flag", r.Error);
-    }
-
-    [Fact]
-    public void StreamFlag_ReturnsComingSoonError()
-    {
-        var r = Helpers.ParseArgs(["--endpoint", "u", "--token", "t", "--stream"]);
-        Assert.NotNull(r.Error);
-        Assert.Contains("--stream is not supported", r.Error);
-        Assert.Contains("coming soon", r.Error);
     }
 
     [Fact]
@@ -146,4 +138,12 @@ public class ArgParsingTests
         Assert.False(r.ShowWire);
     }
 
+    [Fact]
+    public void ShowWire_CombinesWithStream()
+    {
+        var r = Helpers.ParseArgs(["-e", "https://example.com", "-t", "tok", "--show-wire", "--stream"]);
+        Assert.Null(r.Error);
+        Assert.True(r.ShowWire);
+        Assert.True(r.Stream);
+    }
 }

--- a/dotnet/a2a-raw.tests/ExtractTextTests.cs
+++ b/dotnet/a2a-raw.tests/ExtractTextTests.cs
@@ -140,7 +140,49 @@ public class ExtractTextTests
         Assert.Equal("Hello world", Helpers.ExtractText(el));
     }
 
+    // ── ExtractText: result.artifactUpdate (streaming) ─────────────────
+
+    [Fact]
+    public void ExtractText_StreamingArtifactUpdate_ReturnsArtifactText()
+    {
+        var el = Parse("""
+        {
+            "artifactUpdate": {
+                "taskId": "t1",
+                "contextId": "ctx-1",
+                "artifact": {
+                    "artifactId": "a1",
+                    "parts": [{ "text": "streamed" }]
+                }
+            }
+        }
+        """);
+        Assert.Equal("streamed", Helpers.ExtractText(el));
+    }
+
     // ── ExtractText: shapes that should NOT yield answer text ──────────
+
+    [Fact]
+    public void ExtractText_StreamingStatusUpdate_ReturnsEmpty()
+    {
+        // statusUpdate is for chain-of-thought / terminal state, not the
+        // final answer text. Even when it carries a message, ExtractText
+        // returns empty — the sample handles statusUpdate explicitly in
+        // Program.cs to render thoughts in gray.
+        var el = Parse("""
+        {
+            "statusUpdate": {
+                "taskId": "t1",
+                "contextId": "ctx-1",
+                "status": {
+                    "state": "TASK_STATE_WORKING",
+                    "message": { "parts": [{ "text": "thinking..." }] }
+                }
+            }
+        }
+        """);
+        Assert.Equal("", Helpers.ExtractText(el));
+    }
 
     [Fact]
     public void ExtractText_EmptyObject_ReturnsEmpty()

--- a/dotnet/a2a-raw/Helpers.cs
+++ b/dotnet/a2a-raw/Helpers.cs
@@ -9,7 +9,7 @@ namespace WorkIQ.A2ARaw;
 public record RawArgs(
     string? Endpoint, string? Token, string? AppId, string? Account,
     string? Scope, string? Tenant, string? AgentId,
-    bool AllHeaders, bool ShowWire, string? Error);
+    bool Stream, bool AllHeaders, bool ShowWire, string? Error);
 
 public static class Helpers
 {
@@ -18,7 +18,7 @@ public static class Helpers
     public static RawArgs ParseArgs(string[] args)
     {
         string? endpoint = null, token = null, appId = null, account = null, scope = null, tenant = null, agentId = null;
-        bool allHeaders = false, showWire = false;
+        bool stream = false, allHeaders = false, showWire = false;
 
         for (int i = 0; i < args.Length; i++)
         {
@@ -45,29 +45,30 @@ public static class Helpers
                 case "--agent-id" or "-A":
                     if (i + 1 >= args.Length) return Err($"Missing value for {args[i]}");
                     agentId = args[++i]; break;
+                case "--stream": stream = true; break;
                 case "--all-headers": allHeaders = true; break;
                 case "--show-wire": showWire = true; break;
-                case "--stream":
-                    return Err("--stream is not supported: streaming responses are coming soon to this sample. Use the sync mode (default) for now.");
                 default:
                     return Err($"Unknown flag: {args[i]}");
             }
         }
 
-        return new RawArgs(endpoint, token, appId, account, scope, tenant, agentId, allHeaders, showWire, null);
+        return new RawArgs(endpoint, token, appId, account, scope, tenant, agentId, stream, allHeaders, showWire, null);
 
-        static RawArgs Err(string msg) => new(null, null, null, null, null, null, null, false, false, msg);
+        static RawArgs Err(string msg) => new(null, null, null, null, null, null, null, false, false, false, msg);
     }
 
     // ── A2A v1.0 response text extraction ──────────────────────────────────
     //
     // Walks an unwrapped JSON-RPC `result` object and returns the answer text.
-    // The agent's answer text lives in artifacts. Status carries metadata
-    // (citations) but not the final answer text.
+    // The agent's answer is in artifacts (sync) or arrives via artifactUpdate
+    // events (streaming). Status / statusUpdate carry chain-of-thought and
+    // terminal-state metadata, not the final answer text.
     //
     // Shapes handled:
-    //   - result.task.artifacts[].parts[text]            ← sync (typical)
+    //   - result.task.artifacts[].parts[text]            ← sync
     //   - result.message.parts[text]                     ← sync, direct Message payload
+    //   - result.artifactUpdate.artifact.parts[text]     ← streaming chunk
 
     public static string ExtractText(JsonElement el)
     {
@@ -79,6 +80,11 @@ public static class Helpers
         // Sync `message` payload (direct reply, no task).
         if (el.TryGetProperty("message", out var m) && TryGetParts(m, out var msgText))
             return msgText;
+
+        // Streaming `artifactUpdate` — text from the artifact's parts.
+        if (el.TryGetProperty("artifactUpdate", out var au) &&
+            au.TryGetProperty("artifact", out var artifact) &&
+            TryGetParts(artifact, out var auText)) return auText;
 
         return "";
     }

--- a/dotnet/a2a-raw/Program.cs
+++ b/dotnet/a2a-raw/Program.cs
@@ -7,7 +7,7 @@
 // Targets the Work IQ Gateway (`https://workiq.svc.cloud.microsoft/a2a/`).
 //
 // Usage:
-//   dotnet run -- --token <JWT|WAM> --appid <client-id> [--account user@tenant.com]
+//   dotnet run -- --token <JWT|WAM> --appid <client-id> [--account user@tenant.com] [--stream]
 
 using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
@@ -34,7 +34,7 @@ if (parsed.Error != null)
 string endpoint = parsed.Endpoint ?? "https://workiq.svc.cloud.microsoft/a2a/";
 string scope = parsed.Scope ?? "api://workiq.svc.cloud.microsoft/.default";
 string? token = parsed.Token, appId = parsed.AppId, account = parsed.Account, tenant = parsed.Tenant, agentId = parsed.AgentId;
-bool allHeaders = parsed.AllHeaders, showWire = parsed.ShowWire;
+bool stream = parsed.Stream, allHeaders = parsed.AllHeaders, showWire = parsed.ShowWire;
 
 if (string.IsNullOrEmpty(token))
 {
@@ -67,8 +67,8 @@ var http = new HttpClient();
 http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
 http.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 // Opt in to A2A v1.0 wire format. Without this header, the server defaults
-// to the v0.3 dispatcher and the v1.0 method name "SendMessage" returns
-// JSON-RPC -32601 "Method not found".
+// to the v0.3 dispatcher and v1.0 method names ("SendMessage" /
+// "SendStreamingMessage") return JSON-RPC -32601 "Method not found".
 http.DefaultRequestHeaders.TryAddWithoutValidation("A2A-Version", "1.0");
 
 // ── Agent card resolution (when --agent-id is set) ───────────────────────
@@ -76,7 +76,7 @@ http.DefaultRequestHeaders.TryAddWithoutValidation("A2A-Version", "1.0");
 // This sample deliberately does the agent-card fetch in raw HTTP + JSON to
 // show what the wire interaction looks like. With --agent-id the sample:
 //   1. GET {endpoint}/{agentId}/.well-known/agent-card.json
-//   2. Parse the JSON to find:   url, name
+//   2. Parse the JSON to find:   url, name, capabilities.streaming
 //   3. Replace the POST target with agentCard.url
 //
 // Without --agent-id the sample posts directly to the gateway endpoint
@@ -100,11 +100,20 @@ if (!string.IsNullOrEmpty(agentId))
         var resolvedUrl = root.GetProperty("url").GetString()
             ?? throw new InvalidOperationException("agent-card.json has no 'url' field");
         var resolvedName = root.TryGetProperty("name", out var n) ? n.GetString() ?? "" : "";
+        var streamingSupported = root.TryGetProperty("capabilities", out var caps)
+            && caps.TryGetProperty("streaming", out var s) && s.GetBoolean();
 
         Console.WriteLine($"Agent card:");
         Console.WriteLine($"  id              {agentId}");
         Console.WriteLine($"  name            {resolvedName}");
         Console.WriteLine($"  url             {resolvedUrl}");
+        Console.WriteLine($"  streaming       {streamingSupported}");
+
+        if (stream && !streamingSupported)
+        {
+            Console.WriteLine("  note: agent does not advertise streaming; falling back to sync");
+            stream = false;
+        }
 
         endpoint = resolvedUrl;
     }
@@ -118,6 +127,7 @@ if (!string.IsNullOrEmpty(agentId))
 string? contextId = null;
 
 Console.WriteLine($"Connected to: {endpoint}");
+Console.WriteLine($"Mode: {(stream ? "streaming (SendStreamingMessage)" : "sync (SendMessage)")}");
 Console.WriteLine("Type a message. 'quit' to exit.\n");
 
 // ── Chat loop ────────────────────────────────────────────────────────────
@@ -189,12 +199,12 @@ while (true)
             },
         };
 
-        // Wrap in JSON-RPC envelope — v1.0 method name: SendMessage.
+        // Wrap in JSON-RPC envelope — v1.0 method names: SendMessage / SendStreamingMessage.
         var jsonRpcRequest = new
         {
             jsonrpc = "2.0",
             id = Guid.NewGuid().ToString(),
-            method = "SendMessage",
+            method = stream ? "SendStreamingMessage" : "SendMessage",
             @params = new { message },
         };
 
@@ -203,7 +213,14 @@ while (true)
 
         if (showWire) PrintWireBody("▶ POST request", json);
 
-        await SyncResponse(http, endpoint, content, spinnerCts, spinnerTask, showWire);
+        if (stream)
+        {
+            await StreamResponse(http, endpoint, content, spinnerCts, spinnerTask, showWire);
+        }
+        else
+        {
+            await SyncResponse(http, endpoint, content, spinnerCts, spinnerTask, showWire);
+        }
     }
     catch (Exception ex)
     {
@@ -275,18 +292,164 @@ async Task SyncResponse(HttpClient client, string ep, HttpContent body, Cancella
     }
 }
 
-// Walks a v1.0 sync `result` envelope for the contextId. v1.0 places contextId
-// on result.task or result.message.
+// Walks a v1.0 `result` envelope for the contextId. v1.0 places contextId on
+// task / message / statusUpdate / artifactUpdate directly.
 static string? ExtractContextId(JsonElement el)
 {
     static string? Get(JsonElement e) => e.TryGetProperty("contextId", out var c) ? c.GetString() : null;
 
-    foreach (var key in new[] { "task", "message" })
+    foreach (var key in new[] { "task", "message", "statusUpdate", "artifactUpdate" })
     {
         if (el.TryGetProperty(key, out var inner) && Get(inner) is { } id)
             return id;
     }
     return Get(el);
+}
+
+// ── Streaming: POST to base URL with method "SendStreamingMessage" (SSE) ──
+
+async Task StreamResponse(HttpClient client, string ep, HttpContent body, CancellationTokenSource spinCts, Task spinTask, bool showWire)
+{
+    // v1.0: POST to the base URL — method (`SendStreamingMessage`) is inside the JSON-RPC body.
+    var request = new HttpRequestMessage(HttpMethod.Post, ep) { Content = body };
+    request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+    var res = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+
+    // Stop spinner now that we have a response
+    spinCts.Cancel();
+    try { await spinTask; } catch { }
+
+    PrintResponseHeaders(res);
+
+    if (!res.IsSuccessStatusCode)
+    {
+        var errBody = await res.Content.ReadAsStringAsync();
+        Console.ForegroundColor = ConsoleColor.Red;
+        Console.WriteLine($"  {errBody}");
+        Console.ResetColor();
+        return;
+    }
+
+    var responseStream = await res.Content.ReadAsStreamAsync();
+    using var reader = new StreamReader(responseStream);
+
+    // A2A v1.0 streaming semantics:
+    //   result.task            -> initial submitted task (informational)
+    //   result.statusUpdate    -> chain-of-thought OR terminal status; the
+    //                             final event carries citation metadata
+    //   result.artifactUpdate  -> answer chunks. Each event has an `append`
+    //                             flag: true => append parts to the artifact
+    //                             identified by artifactId; false => replace.
+    //                             The full answer is the concatenation of all
+    //                             append=true parts (with replaces applied).
+    //   result.message         -> direct message reply (rare in this flow)
+    var artifactBuffers = new Dictionary<string, StringBuilder>();
+    var lastChainOfThought = "";
+
+    while (!reader.EndOfStream)
+    {
+        var line = await reader.ReadLineAsync();
+        if (line == null) break;
+
+        // SSE format: lines starting with "data:" contain JSON-RPC responses
+        if (!line.StartsWith("data:", StringComparison.Ordinal)) continue;
+        var data = line["data:".Length..].Trim();
+        if (string.IsNullOrEmpty(data)) continue;
+
+        if (showWire) PrintWireBody("← SSE data", data);
+
+        try
+        {
+            using var doc = JsonDocument.Parse(data);
+
+            // Unwrap JSON-RPC: get the "result" field
+            JsonElement payload;
+            if (doc.RootElement.TryGetProperty("result", out var result))
+                payload = result;
+            else
+                payload = doc.RootElement;
+
+            // Extract contextId (v1.0: lives on task/message/statusUpdate/artifactUpdate)
+            contextId = ExtractContextId(payload) ?? contextId;
+
+            // Dispatch on event shape.
+            if (payload.TryGetProperty("artifactUpdate", out var au))
+            {
+                if (au.TryGetProperty("artifact", out var artifact))
+                {
+                    var aId = artifact.TryGetProperty("artifactId", out var aIdProp) ? aIdProp.GetString() ?? "" : "";
+                    var append = au.TryGetProperty("append", out var ap) && ap.ValueKind == JsonValueKind.True;
+
+                    if (Helpers.TryGetParts(artifact, out var chunk))
+                    {
+                        if (!artifactBuffers.TryGetValue(aId, out var sb))
+                        {
+                            sb = new StringBuilder();
+                            artifactBuffers[aId] = sb;
+                        }
+
+                        if (append)
+                        {
+                            // Delta semantics: chunk is the new tail.
+                            sb.Append(chunk);
+                            Console.Write(chunk);
+                        }
+                        else
+                        {
+                            // Replace semantics: chunk is the full new artifact text.
+                            // Work IQ's Full streaming mode sends each event as a
+                            // strict prefix-extension of the previous, so we print
+                            // only the new suffix (terminals can't un-write).
+                            var oldText = sb.ToString();
+                            sb.Clear();
+                            sb.Append(chunk);
+
+                            string toWrite;
+                            if (chunk.StartsWith(oldText, StringComparison.Ordinal))
+                            {
+                                toWrite = chunk[oldText.Length..];
+                            }
+                            else
+                            {
+                                // Defensive: replacement isn't an extension.
+                                if (oldText.Length > 0) Console.WriteLine();
+                                toWrite = chunk;
+                            }
+
+                            if (toWrite.Length > 0) Console.Write(toWrite);
+                        }
+                    }
+                }
+            }
+            else if (payload.TryGetProperty("statusUpdate", out var su))
+            {
+                // Chain-of-thought / progress message (gray, on its own line),
+                // OR terminal state (just signals end of stream).
+                if (su.TryGetProperty("status", out var status))
+                {
+                    if (status.TryGetProperty("message", out var statusMsg) &&
+                        Helpers.TryGetParts(statusMsg, out var thought) &&
+                        thought != lastChainOfThought)
+                    {
+                        Console.ForegroundColor = ConsoleColor.DarkGray;
+                        Console.WriteLine($"\n  [{thought}]");
+                        Console.ResetColor();
+                        lastChainOfThought = thought;
+                    }
+                }
+            }
+            else if (payload.TryGetProperty("message", out var m) &&
+                     Helpers.TryGetParts(m, out var msgText))
+            {
+                Console.Write(msgText);
+            }
+            // result.task -> initial; nothing to print at default verbosity.
+        }
+        catch { /* skip unparseable SSE events */ }
+    }
+
+    Console.WriteLine();
 }
 
 // ── WAM auth ─────────────────────────────────────────────────────────────
@@ -416,19 +579,21 @@ void PrintUsage()
       --account        Account hint (e.g., user@contoso.com)
       --tenant, -T     Tenant ID or domain (required with WAM for single-tenant apps;
                        defaults to 'common' for multi-tenant apps)
+      --stream         Use streaming mode (SSE via message/stream)
       --all-headers    Print all response headers (default: key diagnostics only)
-      --show-wire      Pretty-print raw JSON-RPC request/response bodies.
+      --show-wire      Pretty-print raw JSON-RPC request/response bodies (and each
+                       streaming SSE `data:` event as it arrives).
 
     Examples:
       # Work IQ Gateway (uses defaults)
       dotnet run -- -t WAM -a <appid>
 
+      # List agents (discover IDs to use with --agent-id)
+
       # Invoke a specific agent
       dotnet run -- -t WAM -a <appid> --agent-id <AGENT_ID>
 
       # With a pre-obtained JWT
-      dotnet run -- -t eyJ0eXAi...
-
-    Note: streaming responses are coming soon and not yet supported by this sample.
+      dotnet run -- -t eyJ0eXAi... --stream
     """);
 }

--- a/dotnet/a2a-raw/README.md
+++ b/dotnet/a2a-raw/README.md
@@ -43,7 +43,9 @@ dotnet run -- --token WAM --appid <APP_ID> --tenant <TENANT_ID>
 
 Type a message, see a response, type `quit` to exit.
 
-> **Streaming responses are coming soon** and not yet supported by this sample.
+### Streaming mode
+
+Add `--stream` to switch from `SendMessage` to `SendStreamingMessage`.
 
 ### Invoking a specific agent (`--agent-id`)
 
@@ -60,11 +62,14 @@ The sample then does **two raw HTTP calls** — illustrating exactly what a non-
    GET {endpoint}/{agent-id}/.well-known/agent-card.json
    Authorization: Bearer <token>
    ```
-   Response is the standard A2A agent card JSON. The sample parses two fields:
+   Response is the standard A2A agent card JSON. The sample parses three fields:
    - `url` — where to POST messages for this agent
    - `name` — friendly name (for logging)
+   - `capabilities.streaming` — whether `SendStreamingMessage` is supported
 
 2. **Message post** — same JSON-RPC shape as before, but POSTed to `agentCard.url` (read from step 1) instead of the gateway A2A endpoint.
+
+If `--stream` is set but the agent's card has `capabilities.streaming = false`, the sample falls back to `SendMessage` automatically and prints a note.
 
 #### Agent card wire format (what the GET returns)
 
@@ -136,7 +141,8 @@ You > quit
 | `--tenant, -T` | Tenant ID or domain. Required with `WAM` for single-tenant apps; defaults to `common` for multi-tenant. |
 | `--account` | Account hint for WAM (e.g., `user@contoso.com`) |
 | `--agent-id, -A` | Invoke a specific agent (fetches `.well-known/agent-card.json` and POSTs to `agentCard.url`). See [How to find an agent ID](#how-to-find-an-agent-id) above. |
-| `--show-wire` | Pretty-print raw JSON-RPC request/response bodies. Useful for protocol debugging. |
+| `--show-wire` | Pretty-print raw JSON-RPC request/response bodies and each streaming SSE `data:` event as it arrives. Useful for protocol debugging. |
+| `--stream` | Use streaming mode (`SendStreamingMessage` via SSE) |
 | `--all-headers` | Print every response header (default: only diagnostic ones) |
 
 ## What goes over the wire
@@ -184,17 +190,28 @@ Response is a JSON-RPC envelope with `result.task` containing the agent's task a
 }
 ```
 
-### Streaming responses
+### Streaming: `POST` with method `SendStreamingMessage`
 
-Streaming (`SendStreamingMessage` over SSE) is **coming soon** and not yet supported by this sample.
+Same JSON-RPC request with `"method": "SendStreamingMessage"`. Response is `text/event-stream` (SSE) where each event is a JSON-RPC response carrying one of `task`, `statusUpdate`, `artifactUpdate`, or `message`:
+
+```
+data: {"jsonrpc":"2.0","id":"...","result":{"statusUpdate":{"taskId":"<t>","contextId":"ctx-1","status":{"state":"TASK_STATE_WORKING"}}}}
+data: {"jsonrpc":"2.0","id":"...","result":{"artifactUpdate":{"taskId":"<t>","contextId":"ctx-1","artifact":{"artifactId":"<a>","parts":[{"text":"You"}]}}}}
+data: {"jsonrpc":"2.0","id":"...","result":{"artifactUpdate":{"taskId":"<t>","contextId":"ctx-1","artifact":{"artifactId":"<a>","parts":[{"text":"You have 3 meetings..."}]}}}}
+data: {"jsonrpc":"2.0","id":"...","result":{"statusUpdate":{"taskId":"<t>","contextId":"ctx-1","status":{"state":"TASK_STATE_COMPLETED"}}}}
+```
+
+### Streaming mode
+
+The default mode is `"Delta"` — each `artifactUpdate` carries just the new tail with `append: true`. The sample concatenates `append: true` parts per `artifactId` to assemble the full answer.
 
 ### Key v1.0 protocol details
 
 - **JSON-RPC envelope required** — every request must include `jsonrpc`, `id`, `method`, `params`.
-- **POST to base URL** — the method (`SendMessage`) is inside the body, not in the URL path.
+- **POST to base URL** — the method (`SendMessage`, `SendStreamingMessage`) is inside the body, not in the URL path.
 - **No `kind` discriminators** — parts are flat objects with field-presence (`{"text": "..."}` not `{"kind": "text", "text": "..."}`).
 - **PROTOJSON enums** — roles use `ROLE_USER` / `ROLE_AGENT`; states use `TASK_STATE_WORKING` / `TASK_STATE_COMPLETED` / `TASK_STATE_FAILED` / etc.
-- **Named result wrappers** — sync responses carry `result.task` or `result.message`.
+- **Named result wrappers** — sync responses carry `result.task` or `result.message`; streaming events use `result.statusUpdate`, `result.artifactUpdate`, `result.task`, or `result.message`.
 - **Backward compatibility** — set the `A2A-Version: 0.3` request header to opt back into the v0.3 wire format.
 
 ## NuGet dependencies

--- a/dotnet/a2a.tests/ArgParsingTests.cs
+++ b/dotnet/a2a.tests/ArgParsingTests.cs
@@ -15,10 +15,11 @@ public class ArgParsingTests
     [Fact]
     public void ValidArgs_ProduceCorrectConfig()
     {
-        var r = Helpers.ParseArgs(["--token", "mytoken", "--appid", "app1"]);
+        var r = Helpers.ParseArgs(["--token", "mytoken", "--appid", "app1", "--stream"]);
         Assert.Null(r.Error);
         Assert.Equal("mytoken", r.Token);
         Assert.Equal("app1", r.AppId);
+        Assert.True(r.Stream);
     }
 
     [Fact]
@@ -27,15 +28,6 @@ public class ArgParsingTests
         var r = Helpers.ParseArgs([]);
         Assert.Null(r.Error);
         Assert.Null(r.Token);
-    }
-
-    [Fact]
-    public void StreamFlag_ReturnsComingSoonError()
-    {
-        var r = Helpers.ParseArgs(["--token", "t", "--stream"]);
-        Assert.NotNull(r.Error);
-        Assert.Contains("--stream is not supported", r.Error);
-        Assert.Contains("coming soon", r.Error);
     }
 
     [Fact]

--- a/dotnet/a2a/Helpers.cs
+++ b/dotnet/a2a/Helpers.cs
@@ -9,7 +9,7 @@ namespace WorkIQ.A2A;
 public record A2AArgs(
     string? Token, string? AppId, string? Endpoint, string? Account, string? Tenant,
     string? AgentId,
-    bool ShowToken, bool ShowWire,
+    bool ShowToken, bool Stream, bool ShowWire,
     int Verbosity, List<string> Headers, string? Error);
 
 public static class Helpers
@@ -19,7 +19,7 @@ public static class Helpers
     public static A2AArgs ParseArgs(string[] args)
     {
         string? token = null, appId = null, endpoint = null, account = null, tenant = null, agentId = null;
-        bool showToken = false, showWire = false;
+        bool showToken = false, stream = false, showWire = false;
         int verbosity = 1;
         var headers = new List<string>();
 
@@ -46,6 +46,7 @@ public static class Helpers
                     if (i + 1 >= args.Length) return Err($"Missing value for {args[i]}");
                     agentId = args[++i]; break;
                 case "--show-token": showToken = true; break;
+                case "--stream": stream = true; break;
                 case "--show-wire": showWire = true; break;
                 case "--verbosity" or "-v":
                     if (i + 1 >= args.Length) return Err($"Missing value for {args[i]}");
@@ -55,39 +56,30 @@ public static class Helpers
                 case "--header" or "-H":
                     if (i + 1 >= args.Length) return Err($"Missing value for {args[i]}");
                     headers.Add(args[++i]); break;
-                case "--stream":
-                    return Err("--stream is not supported: streaming responses are coming soon to this sample. Use the sync mode (default) for now.");
                 default:
                     return Err($"Unknown flag: {args[i]}");
             }
         }
 
-        return new A2AArgs(token, appId, endpoint, account, tenant, agentId, showToken, showWire, verbosity, headers, null);
+        return new A2AArgs(token, appId, endpoint, account, tenant, agentId, showToken, stream, showWire, verbosity, headers, null);
 
-        static A2AArgs Err(string msg) => new(null, null, null, null, null, null, false, false, 1, new List<string>(), msg);
+        static A2AArgs Err(string msg) => new(null, null, null, null, null, null, false, false, false, 1, new List<string>(), msg);
     }
 
     // ── Sync response extraction (A2A SDK v1.0 SendMessageResponse) ─────
 
-    public static (string text, string? contextId, Dictionary<string, JsonElement>? metadata) Extract(SendMessageResponse response)
+    public static (string text, string? contextId, Dictionary<string, JsonElement>? metadata) Extract(SendMessageResponse response) => response.PayloadCase switch
     {
-        switch (response.PayloadCase)
-        {
-            case SendMessageResponseCase.Message:
-            {
-                var m = response.Message!;
-                return (JoinText(m.Parts), m.ContextId, m.Metadata);
-            }
-            case SendMessageResponseCase.Task:
-            {
-                var t = response.Task!;
-                // Citations: still in Status.Message.Metadata until DataPart migration ships.
-                return (ExtractTextFromTask(t), t.ContextId, t.Status.Message?.Metadata);
-            }
-            default:
-                return ("(no response)", null, null);
-        }
-    }
+        SendMessageResponseCase.Message => (
+            JoinText(response.Message!.Parts),
+            response.Message.ContextId,
+            response.Message.Metadata),
+        SendMessageResponseCase.Task => (
+            ExtractTextFromTask(response.Task!),
+            response.Task.ContextId,
+            response.Task.Status.Message?.Metadata),    // citations: still in Status.Message.Metadata until DataPart migration ships
+        _ => ("(no response)", null, null),
+    };
 
     // The agent's answer text is delivered in Artifacts[].Parts (text parts).
     // Status.Message carries chain-of-thought / progress and metadata, not the

--- a/dotnet/a2a/Program.cs
+++ b/dotnet/a2a/Program.cs
@@ -46,6 +46,7 @@ var httpClient = CreateHttpClient(token, config.Gateway);
 //   --agent-id set:     fetch the agent card from {gateway}/{agentId}/.well-known/agent-card.json
 //                       (handled by A2ACardResolver) and use agentCard.Url as the A2A endpoint.
 string a2aEndpoint = config.Gateway.Endpoint;
+bool effectiveStream = config.Stream;
 if (!string.IsNullOrEmpty(config.AgentId))
 {
     var gateway = config.Gateway.Endpoint.TrimEnd('/');
@@ -62,6 +63,12 @@ if (!string.IsNullOrEmpty(config.AgentId))
     // v1.0: AgentCard.Url is gone; the URL lives in SupportedInterfaces[].Url.
     var resolvedUrl = agentCard.SupportedInterfaces.FirstOrDefault()?.Url ?? config.Gateway.Endpoint;
     a2aEndpoint = resolvedUrl;
+    var streamingSupported = agentCard.Capabilities.Streaming == true;
+    if (config.Stream && !streamingSupported)
+    {
+        if (config.Verbosity >= 1) Ink($"  note: agent '{agentCard.Name}' does not advertise streaming; falling back to sync\n", ConsoleColor.DarkYellow);
+        effectiveStream = false;
+    }
 
     if (config.Verbosity >= 1)
     {
@@ -69,6 +76,7 @@ if (!string.IsNullOrEmpty(config.AgentId))
         Console.WriteLine($"  id              {config.AgentId}");
         Console.WriteLine($"  name            {agentCard.Name}");
         Console.WriteLine($"  url             {resolvedUrl}");
+        Console.WriteLine($"  streaming       {streamingSupported}");
     }
 }
 
@@ -77,7 +85,7 @@ string? contextId = null;
 
 if (config.Verbosity >= 1)
 {
-    Log($"READY — {config.Gateway.Name} — {a2aEndpoint}");
+    Log($"READY — {config.Gateway.Name} — {(effectiveStream ? "Streaming" : "Sync")} — {a2aEndpoint}");
     Console.WriteLine("Type a message. 'quit' to exit.\n");
 }
 
@@ -119,13 +127,160 @@ while (true)
         var sw = Stopwatch.StartNew();
         Dictionary<string, JsonElement>? responseMetadata = null;
 
-        var response = await a2a.SendMessageAsync(new SendMessageRequest { Message = msg });
-        sw.Stop();
-        spinner.Stop();
-        var (text, ctx, meta) = Extract(response);
-        contextId = ctx;
-        responseMetadata = meta;
-        Console.WriteLine(text);
+        if (effectiveStream)
+        {
+            // A2A v1.0 streaming semantics:
+            //   - Task         : initial submitted state — informational only.
+            //   - StatusUpdate : chain-of-thought / progress messages OR the
+            //                    terminal state (Completed/Failed/...). The
+            //                    final StatusUpdate carries citation metadata
+            //                    in Status.Message.Metadata; its Parts are
+            //                    typically empty and never the "answer".
+            //   - ArtifactUpdate : the answer, streamed in chunks. Each event
+            //                    carries one or more parts and an Append flag:
+            //                      Append=true  -> append parts to the
+            //                        artifact identified by ArtifactId
+            //                      Append=false -> replace the artifact
+            //                        identified by ArtifactId.
+            //                    The full answer is the concatenation of all
+            //                    Append=true parts (with replaces applied) for
+            //                    each ArtifactId.
+            var artifactBuffers = new Dictionary<string, StringBuilder>();
+            var lastChainOfThought = string.Empty;
+
+            await foreach (var evt in a2a.SendStreamingMessageAsync(new SendMessageRequest { Message = msg }))
+            {
+                if (config.ShowWire) PrintStreamEvent(evt);
+
+                switch (evt.PayloadCase)
+                {
+                    case StreamResponseCase.Task:
+                    {
+                        contextId = evt.Task!.ContextId;
+                        if (config.Verbosity >= 2)
+                            Ink($"  [task {ShortId(evt.Task.Id)} {evt.Task.Status.State}]\n", ConsoleColor.DarkGray);
+                        break;
+                    }
+                    case StreamResponseCase.StatusUpdate:
+                    {
+                        var su = evt.StatusUpdate!;
+                        if (config.Verbosity >= 2)
+                            Ink($"  [{su.Status.State}]\n", ConsoleColor.DarkGray);
+
+                        if (su.Status.Message is { } statusMsg)
+                        {
+                            contextId = statusMsg.ContextId;
+                            responseMetadata = statusMsg.Metadata;
+
+                            // Chain-of-thought: print once per unique progress line,
+                            // in gray, on its own line. Skipped for the terminal
+                            // event whose Parts are typically empty.
+                            var thought = Helpers.JoinText(statusMsg.Parts);
+                            if (!string.IsNullOrEmpty(thought) && thought != lastChainOfThought)
+                            {
+                                spinner.Stop();
+                                Ink($"  [{thought}]\n", ConsoleColor.DarkGray);
+                                lastChainOfThought = thought;
+                            }
+                        }
+
+                        if (IsTerminal(su.Status.State))
+                        {
+                            spinner.Stop();
+                            sw.Stop();
+                            Console.WriteLine();
+                            goto streaming_done;
+                        }
+                        break;
+                    }
+                    case StreamResponseCase.ArtifactUpdate:
+                    {
+                        var au = evt.ArtifactUpdate!;
+                        var aId = au.Artifact.ArtifactId;
+                        if (!artifactBuffers.TryGetValue(aId, out var sb))
+                        {
+                            sb = new StringBuilder();
+                            artifactBuffers[aId] = sb;
+                        }
+
+                        var chunk = Helpers.JoinText(au.Artifact.Parts);
+
+                        if (au.Append)
+                        {
+                            // Delta semantics: chunk is the new tail.
+                            sb.Append(chunk);
+                            if (chunk.Length > 0)
+                            {
+                                spinner.Stop();
+                                Console.Write(chunk);
+                            }
+                        }
+                        else
+                        {
+                            // Replace semantics: chunk is the full new artifact text.
+                            // Work IQ's Full streaming mode sends each event as a
+                            // strict prefix-extension of the previous, so we print
+                            // only the new suffix (terminals can't un-write).
+                            var oldText = sb.ToString();
+                            sb.Clear();
+                            sb.Append(chunk);
+
+                            string toWrite;
+                            if (chunk.StartsWith(oldText, StringComparison.Ordinal))
+                            {
+                                toWrite = chunk[oldText.Length..];
+                            }
+                            else
+                            {
+                                // Defensive: replacement isn't an extension. Newline
+                                // and reprint, so the user can see the new content.
+                                if (oldText.Length > 0) Console.WriteLine();
+                                toWrite = chunk;
+                            }
+
+                            if (toWrite.Length > 0)
+                            {
+                                spinner.Stop();
+                                Console.Write(toWrite);
+                            }
+                        }
+
+                        // Per-chunk markers are too noisy at -v 2 (the gateway can
+                        // emit very small chunks, fragmenting the streamed answer).
+                        // Show them only with --show-wire alongside the raw event JSON.
+                        if (config.ShowWire)
+                            Ink($"  [artifact {ShortId(aId)} +{chunk.Length}c{(au.LastChunk ? " LAST" : "")}]\n", ConsoleColor.DarkGray);
+                        break;
+                    }
+                    case StreamResponseCase.Message:
+                    {
+                        contextId = evt.Message!.ContextId;
+                        responseMetadata = evt.Message.Metadata;
+                        var text = Helpers.JoinText(evt.Message.Parts);
+                        if (text.Length > 0)
+                        {
+                            spinner.Stop();
+                            Console.Write(text);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            sw.Stop();
+            Console.WriteLine();
+            streaming_done:;
+        }
+        else
+        {
+            var response = await a2a.SendMessageAsync(new SendMessageRequest { Message = msg });
+            sw.Stop();
+            spinner.Stop();
+            var (text, ctx, meta) = Extract(response);
+            contextId = ctx;
+            responseMetadata = meta;
+            Console.WriteLine(text);
+        }
 
         if (config.Verbosity >= 1) Ink($"  ({sw.ElapsedMilliseconds} ms)\n", ConsoleColor.DarkGray);
 
@@ -147,6 +302,11 @@ while (true)
 static (string text, string? contextId, Dictionary<string, JsonElement>? metadata) Extract(SendMessageResponse response)
     => WorkIQ.A2A.Helpers.Extract(response);
 
+static bool IsTerminal(TaskState state) =>
+    state == TaskState.Completed || state == TaskState.Failed || state == TaskState.Canceled || state == TaskState.Rejected;
+
+static string ShortId(string id) => id.Length > 8 ? id[..8] : id;
+
 static HttpClient CreateHttpClient(string bearerToken, GatewayConfig gw)
 {
     var client = new HttpClient(new WireLog { InnerHandler = new HttpClientHandler() }) { Timeout = TimeSpan.FromMinutes(5) };
@@ -158,6 +318,40 @@ static HttpClient CreateHttpClient(string bearerToken, GatewayConfig gw)
     }
 
     return client;
+}
+
+// Prints each parsed streaming event as JSON. The A2A SDK has already consumed
+// the raw `data:` line by the time we get here, so we re-serialize the parsed
+// StreamResponse payload back to JSON. The visible JSON shape matches what the
+// server sent inside `result` (the SDK strips the outer `{jsonrpc, id, result}`
+// envelope during parsing).
+static void PrintStreamEvent(StreamResponse evt)
+{
+    object? data = evt.PayloadCase switch
+    {
+        StreamResponseCase.Task => evt.Task,
+        StreamResponseCase.Message => evt.Message,
+        StreamResponseCase.StatusUpdate => evt.StatusUpdate,
+        StreamResponseCase.ArtifactUpdate => evt.ArtifactUpdate,
+        _ => null,
+    };
+    if (data is null) return;
+
+    string json;
+    try
+    {
+        json = JsonSerializer.Serialize(data, new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+        });
+    }
+    catch (Exception ex) { json = $"(serialize failed: {ex.Message})"; }
+
+    Console.ForegroundColor = ConsoleColor.DarkGray;
+    Console.WriteLine($"\n  ← data ({evt.PayloadCase}):");
+    foreach (var line in json.Split('\n')) Console.WriteLine($"      {line}");
+    Console.ResetColor();
 }
 
 // ── WAM auth ─────────────────────────────────────────────────────────────
@@ -266,11 +460,10 @@ static void PrintUsage()
                            gateway's default agent).
           --header, -H     Custom HTTP header in 'Key: Value' format (repeatable)
           --show-token     Print the raw JWT token (for reuse with --token)
-          --show-wire      Pretty-print raw JSON-RPC request/response bodies.
-                           Independent of --verbosity.
+          --stream         Use streaming mode (SSE via message/stream)
+          --show-wire      Pretty-print raw JSON-RPC request/response bodies (and streaming
+                           SSE events). Independent of --verbosity.
           -v, --verbosity  0 = response only, 1 = default, 2 = wire diagnostics
-
-        Note: streaming responses are coming soon and not yet supported by this sample.
 
         Examples:
           dotnet run -- --token WAM --appid <your-app-id> --tenant <your-tenant>
@@ -292,7 +485,7 @@ static Config? ParseArgs(string[] args)
     }
 
     string? token = a.Token, appId = a.AppId, endpoint = a.Endpoint, account = a.Account, tenant = a.Tenant, agentId = a.AgentId;
-    bool showToken = a.ShowToken, showWire = a.ShowWire;
+    bool showToken = a.ShowToken, stream = a.Stream, showWire = a.ShowWire;
     int verbosity = a.Verbosity;
     var headers = a.Headers;
 
@@ -322,7 +515,7 @@ static Config? ParseArgs(string[] args)
         gw = gw with { ExtraHeaders = [.. gw.ExtraHeaders, .. headers] };
     }
 
-    return new Config(token, appId ?? "", gw, account, tenant, agentId, showToken, verbosity, showWire);
+    return new Config(token, appId ?? "", gw, account, tenant, agentId, showToken, verbosity, stream, showWire);
 }
 
 // ── Citations ─────────────────────────────────────────────────────────────
@@ -381,7 +574,7 @@ static void Ink(string s, ConsoleColor c) { Console.ForegroundColor = c; Console
 [DllImport("user32.dll", ExactSpelling = true)] static extern IntPtr GetAncestor(IntPtr hwnd, uint flags);
 static IntPtr ConsoleWindowHandle() { var c = Win32GetConsoleWindow(); var r = GetAncestor(c, 3); return r != IntPtr.Zero ? r : c; }
 
-record Config(string Token, string AppId, GatewayConfig Gateway, string? Account, string? Tenant, string? AgentId, bool ShowToken, int Verbosity, bool ShowWire);
+record Config(string Token, string AppId, GatewayConfig Gateway, string? Account, string? Tenant, string? AgentId, bool ShowToken, int Verbosity, bool Stream, bool ShowWire);
 
 // ── Gateway definitions ──────────────────────────────────────────────────
 
@@ -448,6 +641,7 @@ class WireLog : DelegatingHandler
         catch (Exception ex) { Ink($"  ◀ ERROR: {ex.Message}\n", ConsoleColor.Red); throw; }
 
         var contentType = res.Content?.Headers.ContentType?.MediaType;
+        var isStreaming = string.Equals(contentType, "text/event-stream", StringComparison.OrdinalIgnoreCase);
 
         if (Verbosity >= 2 || ShowWire)
         {
@@ -465,7 +659,13 @@ class WireLog : DelegatingHandler
             {
                 Console.WriteLine($"    Body: {Trunc(await res.Content.ReadAsStringAsync(ct), 1000)}");
             }
-            // Pretty-print the full body when --show-wire.
+            // For streaming responses, do NOT read the body here (would block until stream closes).
+            // The streaming consumer in the main loop logs each SSE event when --show-wire is set.
+            else if (ShowWire && isStreaming)
+            {
+                Console.WriteLine($"    (streaming response — see SSE events below)");
+            }
+            // For non-streaming JSON success responses, pretty-print the full body when --show-wire.
             else if (ShowWire && IsJson(contentType) && res.Content != null)
             {
                 var text = await res.Content.ReadAsStringAsync(ct);

--- a/dotnet/a2a/README.md
+++ b/dotnet/a2a/README.md
@@ -2,9 +2,7 @@
 
 A minimal, single-file interactive client for communicating with Work IQ agents using the [Agent-to-Agent (A2A) protocol](https://a2a-protocol.org).
 
-Uses the [A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) (NuGet: [`A2A`](https://www.nuget.org/packages/A2A/)) for JSON-RPC transport. Sends synchronous (`SendMessage`) requests against the **Work IQ Gateway**.
-
-> **Streaming responses are coming soon** and not yet supported by this sample.
+Uses the [A2A .NET SDK](https://github.com/a2aproject/a2a-dotnet) (NuGet: [`A2A`](https://www.nuget.org/packages/A2A/)) for JSON-RPC transport. Supports both synchronous (`SendMessage`) and streaming (`SendStreamingMessage`) modes against the **Work IQ Gateway**.
 
 For the lower-level sample with no SDK (raw HTTP + JSON), see [`../a2a-raw/`](../a2a-raw/).
 
@@ -39,6 +37,10 @@ dotnet run -- --token WAM --appid <APP_ID> --tenant <TENANT_ID>
 
 Type a message, see a response, type `quit` to exit.
 
+### Streaming mode
+
+Add `--stream` to switch from `SendMessage` (sync) to `SendStreamingMessage` (SSE).
+
 ### Invoking a specific agent (`--agent-id`)
 
 Without `--agent-id`, the sample posts directly to the gateway endpoint (the default agent). To invoke a specific agent, pass `--agent-id <id>`:
@@ -51,8 +53,9 @@ dotnet run -- --token WAM --agent-id <AGENT_ID> \
 The sample then:
 
 1. Fetches the agent card from `{gateway}/{agent-id}/.well-known/agent-card.json` via the A2A SDK's `A2ACardResolver`.
-2. Reads `agentCard.url` and `agentCard.name` from the response.
+2. Reads `agentCard.url`, `agentCard.name`, `agentCard.capabilities.streaming` from the response.
 3. Uses `agentCard.url` (not the gateway endpoint) as the target for `A2AClient`.
+4. Falls back to sync mode if `--stream` is set but the agent doesn't advertise streaming (a note prints at `-v >= 1`).
 
 <a id="how-to-find-an-agent-id"></a>
 #### How to find an agent ID
@@ -112,7 +115,8 @@ If the `── TOKEN ──` block shows `aud` matching the Work IQ Gateway and 
 | `--tenant, -T` | Tenant ID or domain. Required with `WAM` for single-tenant apps; defaults to `common` for multi-tenant. |
 | `--account` | Account hint for WAM (e.g., `user@contoso.com`) |
 | `--agent-id, -A` | Invoke a specific agent (fetches `{gateway}/{agent-id}/.well-known/agent-card.json` and posts to `agentCard.url`). See [How to find an agent ID](#how-to-find-an-agent-id) above. |
-| `--show-wire` | Pretty-print raw JSON-RPC request/response bodies. Independent of `--verbosity`. Useful for protocol debugging. |
+| `--show-wire` | Pretty-print raw JSON-RPC request/response bodies and each streaming SSE event as it arrives. Independent of `--verbosity`. Useful for protocol debugging. |
+| `--stream` | Use streaming mode (`SendStreamingMessage` via SSE) |
 | `--header, -H` | Custom request header (repeatable) |
 | `--show-token` | Print the raw access token (use only for diagnostics — treat tokens as sensitive) |
 | `-v, --verbosity` | `0` response only, `1` default, `2` full wire |
@@ -129,7 +133,7 @@ If the `── TOKEN ──` block shows `aud` matching the Work IQ Gateway and 
 
 1. **Auth**: acquires a token via WAM or accepts a pre-obtained JWT.
 2. **A2A Client**: creates an `A2AClient` from the A2A .NET SDK pointed at the gateway endpoint.
-3. **Send**: `SendMessage` (sync).
+3. **Send**: `SendMessage` (sync) or `SendStreamingMessage` (streaming).
 4. **Receive**: parses `AgentMessage` or `AgentTask`; extracts text parts and citations from `metadata["attributions"]`.
 5. **Multi-turn**: maintains `contextId` across turns for conversation continuity.
 
@@ -138,7 +142,7 @@ If the `── TOKEN ──` block shows `aud` matching the Work IQ Gateway and 
 | A2A Capability | Status | Notes |
 |---------------|--------|-------|
 | `SendMessage` (sync) | Available | Full request/response cycle |
-| `SendStreamingMessage` (SSE) | Coming soon | Streaming responses are not yet supported by this sample |
+| `SendStreamingMessage` (SSE) | Available | Incremental streaming via `TaskArtifactUpdateEvent` (and `TaskStatusUpdateEvent` for chain-of-thought / terminal status) |
 | Multi-turn (`contextId`) | Available | Conversation state maintained across turns |
 | Text parts (`Part.FromText`) | Available | User and agent text messages |
 | Citations | Available | Via Microsoft-specific `metadata["attributions"]` (see below) |
@@ -184,10 +188,10 @@ if (agentMessage.Metadata?.TryGetValue("attributions", out var attrs) == true
 
 ## A2A protocol notes
 
-- This sample targets **A2A v1.0** wire format: SCREAMING_SNAKE_CASE enums (`ROLE_USER`, `TASK_STATE_COMPLETED`), flat field-presence parts (no `kind` discriminator), and named result wrappers (`result.task`, `result.message`). The method name is `SendMessage`.
-- Answer text comes back in `Artifact.Parts`. `Status.Message` carries citation metadata, not the final answer text.
+- This sample targets **A2A v1.0** wire format: SCREAMING_SNAKE_CASE enums (`ROLE_USER`, `TASK_STATE_COMPLETED`), flat field-presence parts (no `kind` discriminator), and named result wrappers (`result.task`, `result.statusUpdate`, `result.artifactUpdate`). Method names are `SendMessage` / `SendStreamingMessage`.
+- Answer text comes back in `Artifact.Parts` (sync) or via `ArtifactUpdate` events (streaming). `Status.Message` carries chain-of-thought / progress and citation metadata, not the final answer text.
 - Citations and annotations live in `Status.Message.Metadata["attributions"]`. A subsequent change will move citations to a `DataPart` on the artifact (with media type `application/vnd.workiq-reference`); the sample will be updated when that ships.
-- **Streaming responses are coming soon** and not yet supported by this sample.
+- **Streaming mode**: in the default "Delta" mode each `ArtifactUpdate` carries just the new tail with `Append = true`; the sample concatenates `Append = true` parts per `ArtifactId` to assemble the full answer.
 
 ## Wire diagnostics
 


### PR DESCRIPTION
Adds --stream to both dotnet/a2a (SDK-based) and dotnet/a2a-raw (hand-rolled JSON-RPC) samples so customers can see how to consume A2A v1.0 streaming responses end-to-end. Sync mode (SendMessage) remains the default; --stream uses SendStreamingMessage and renders the answer as events arrive.

Per-event handling for the four A2A v1.0 streaming event shapes (Task, StatusUpdate, ArtifactUpdate, Message) with append-aware artifact buffering: Append=true parts concatenate per ArtifactId, Append=false replaces. Chain-of-thought / progress messages from StatusUpdate print on their own line in gray; citations from Status.Message.Metadata ["attributions"] print after the streamed answer (same shape as sync).

Agent-card streaming-capability check: when --agent-id is used, the sample reads agentCard.Capabilities.Streaming and falls back to sync if the agent does not advertise streaming.

--show-wire prints each parsed streaming event as JSON for diagnostics, independent of --verbosity.

a2a-raw issues a SendStreamingMessage JSON-RPC request with Accept: text/event-stream and parses the SSE response line-by-line, dispatching by named result wrapper (result.task, result.statusUpdate, result.artifactUpdate, result.message).

Sync mode and all existing flags (--token, --appid, --agent-id, --header, --show-token, --show-wire, --verbosity, --tenant, --account) are unchanged. READMEs updated with a Streaming mode section explaining the Delta event shape and append-concatenation rule. Tests cover --stream argument parsing and streaming-shape extraction (65/65 passing).